### PR TITLE
PN-17321

### DIFF
--- a/PAS_Database/dbo/Stored Procedures/USP_CopyWorkflowDetailsToWorkOrder.sql
+++ b/PAS_Database/dbo/Stored Procedures/USP_CopyWorkflowDetailsToWorkOrder.sql
@@ -23,6 +23,7 @@
 	7	 11/08/2025	  RAJESH GAMI		Fixed: Save same order as in the template & handle the delete value
 	8	 12/15/2025	  VISHAL SUTHAR		Fixed: Sequence number to copy same as what we have in workflow
 	9	 12/24/2025	  VISHAL SUTHAR		Converting sequence while sorting and adding into workordertask table
+	10	 07-16-2026	  SUMIT KUMAR		Fixed workflow direction copy to preserve template instruction order and append below existing instructions
 
 exec sp_executesql N'EXEC USP_CopyWorkflowDetailsToWorkOrder @WorkOrderId,@WorkflowId,@WorkOrderPartNumberId,@MasterCompanyId,@CreatedBy, @CreatedById, 
 @ListItem ',N'@WorkOrderId bigint,@WorkflowId bigint,@WorkOrderPartNumberId bigint,@MasterCompanyId int,@CreatedBy nvarchar(16),@CreatedById bigint,@listItem nvarchar(28)',
@@ -1288,6 +1289,11 @@ SET NOCOUNT ON;
 										[IsFromWorkFlow] BIT NULL,
 										[NewParentId] [BIGINT] NULL,
 									)
+
+									DECLARE @MaxExistingParentSeq INT = 0;
+									SELECT @MaxExistingParentSeq = ISNULL(MAX(TRY_CAST(SequenceNumber AS INT)), 0)
+									FROM dbo.WorkOrderTaskInstruction WITH (NOLOCK)
+									WHERE WorkOrderTaskId = @WorkOrderTaskId AND ParentId IS NULL AND ISNULL(IsDeleted, 0) = 0;
 									
 									;WITH ParentInstructions AS (
 										SELECT 
@@ -1297,7 +1303,7 @@ SET NOCOUNT ON;
 											WFD.[Action] AS InstructionTitle,
 											WFD.[Description] AS InstructionDetails,
 											T.IsPrintInWO,
-											ROW_NUMBER() OVER (ORDER BY WFD.WorkflowDirectionId) AS ParentSequence
+											ROW_NUMBER() OVER (ORDER BY TRY_CAST(WFD.[Sequence] AS DECIMAL(10, 4)), WFD.WorkflowDirectionId) + @MaxExistingParentSeq AS ParentSequence
 										FROM dbo.WorkflowDirection WFD WITH (NOLOCK)
 										LEFT JOIN dbo.Task T WITH (NOLOCK) ON WFD.TaskId = T.TaskId
 										WHERE WFD.WorkflowId = @WorkflowId 
@@ -1317,7 +1323,7 @@ SET NOCOUNT ON;
 											T.IsPrintInWO,
 											ROW_NUMBER() OVER (
 												PARTITION BY WFD.ParentId 
-												ORDER BY WFD.WorkflowDirectionId
+												ORDER BY TRY_CAST(WFD.[Sequence] AS DECIMAL(10, 4)), WFD.WorkflowDirectionId
 											) AS ChildSequence
 										FROM dbo.WorkflowDirection WFD WITH (NOLOCK)
 										LEFT JOIN dbo.Task T WITH (NOLOCK) ON WFD.TaskId = T.TaskId
@@ -1332,31 +1338,50 @@ SET NOCOUNT ON;
 									INSERT INTO #tmpWorkflowDirection(WorkOrderTaskId,WorkflowDirectionId,ParentId,IsParent,InstructionTitle,SequenceNumber,InstructionDetails,PrintInWO,
 												MasterCompanyId,CreatedBy,UpdatedBy,CreatedDate,UpdatedDate,IsActive,IsDeleted,IsFromWorkFlow)
 									SELECT 
-										@WorkOrderTaskId,
-										p.WorkflowDirectionId,
-										NULL AS ParentId,
-										1 AS IsParent,
-										p.InstructionTitle,
-										CAST(p.ParentSequence AS VARCHAR(100)) AS SequenceNumber,
-										p.InstructionDetails,
-										p.IsPrintInWO,
-										@MasterCompanyId, @CreatedBy, @CreatedBy, GETUTCDATE(), GETUTCDATE(), 1, 0, 1
-									FROM ParentInstructions p
+										WorkOrderTaskId,
+										WorkflowDirectionId,
+										ParentId,
+										IsParent,
+										InstructionTitle,
+										SequenceNumber,
+										InstructionDetails,
+										IsPrintInWO,
+										MasterCompanyId,
+										CreatedBy,
+										UpdatedBy,
+										CreatedDate,
+										UpdatedDate,
+										IsActive,
+										IsDeleted,
+										IsFromWorkFlow
+									FROM (
+										SELECT 
+											@WorkOrderTaskId AS WorkOrderTaskId,
+											p.WorkflowDirectionId,
+											NULL AS ParentId,
+											1 AS IsParent,
+											p.InstructionTitle,
+											CAST(p.ParentSequence AS VARCHAR(100)) AS SequenceNumber,
+											p.InstructionDetails,
+											p.IsPrintInWO,
+											@MasterCompanyId AS MasterCompanyId, @CreatedBy AS CreatedBy, @CreatedBy AS UpdatedBy, GETUTCDATE() AS CreatedDate, GETUTCDATE() AS UpdatedDate, 1 AS IsActive, 0 AS IsDeleted, 1 AS IsFromWorkFlow
+										FROM ParentInstructions p
 
-									UNION ALL
+										UNION ALL
 
-									SELECT 
-										@WorkOrderTaskId,
-										c.WorkflowDirectionId,
-										c.ParentId,
-										0 AS IsParent,
-										c.InstructionTitle,
-										CAST(c.ChildSequence AS VARCHAR(100)) AS SequenceNumber,
-										c.InstructionDetails,
-										c.IsPrintInWO,
-										@MasterCompanyId, @CreatedBy, @CreatedBy, GETUTCDATE(), GETUTCDATE(), 1, 0, 1
-									FROM ChildInstructions c
-									ORDER BY ParentId, IsParent DESC, SequenceNumber;
+										SELECT 
+											@WorkOrderTaskId AS WorkOrderTaskId,
+											c.WorkflowDirectionId,
+											c.ParentId,
+											0 AS IsParent,
+											c.InstructionTitle,
+											CAST(c.ChildSequence AS VARCHAR(100)) AS SequenceNumber,
+											c.InstructionDetails,
+											c.IsPrintInWO,
+											@MasterCompanyId AS MasterCompanyId, @CreatedBy AS CreatedBy, @CreatedBy AS UpdatedBy, GETUTCDATE() AS CreatedDate, GETUTCDATE() AS UpdatedDate, 1 AS IsActive, 0 AS IsDeleted, 1 AS IsFromWorkFlow
+										FROM ChildInstructions c
+									) AS DirectionRows
+									ORDER BY IsParent DESC, ParentId, TRY_CAST(SequenceNumber AS DECIMAL(10, 4)), WorkflowDirectionId;
 
 									--FROM dbo.WorkflowDirection WFD WITH (NOLOCK) 
 									--	LEFT JOIN dbo.Task T WITH (NOLOCK) ON WFD.TaskId = T.TaskId


### PR DESCRIPTION
Modified workflow instruction copy logic to maintain template instruction order by sorting on the Sequence field instead of WorkflowDirectionId. New instructions are now appended below existing ones by calculating the maximum existing parent sequence number. This ensures proper instruction ordering is preserved when copying workflow details to work orders.