### PR TITLE
PN-17478 - Include ' - REV - ' in PublicationId when revision exists

### DIFF
--- a/PAS_Database/dbo/Stored Procedures/USP_GetPartPublications.sql
+++ b/PAS_Database/dbo/Stored Procedures/USP_GetPartPublications.sql
@@ -16,6 +16,7 @@
     1    27/06/2025  Moin Bloch			Created
     2    01/07/2025  Devendra Shekh     Allowing to fetch @cmmIds data Despite being Deleted/InActive
     3    11/02/2026   AYUSHI PATEL      Fixed duplicate record issue when applying revisionNumber logic.Moved COUNT() OVER() calculation to outer query after UNION to ensure consistent PublicationId formatting.
+    4    30/07/2026   SUMIT KUMAR      Changed the 'PublicationId' formatting with {Template Description} – REV – {Revision #} if Revision num is there [PN-17478]
  
 --   EXEC [dbo].[USP_GetPartPublications] 102544,1,'711'
      EXEC [dbo].[USP_GetPartPublications] 102544,1,''
@@ -36,8 +37,8 @@ BEGIN
 	BEGIN
 		SELECT 
 			CASE 
-				WHEN COUNT(*) OVER (PARTITION BY p.PublicationId) > 1
-				THEN p.PublicationId + '_' + CAST(p.RevisionNum AS VARCHAR(20))
+				WHEN COUNT(*) OVER (PARTITION BY p.PublicationId) > 1 AND NULLIF(LTRIM(RTRIM(p.RevisionNum)), '') IS NOT NULL
+				THEN p.PublicationId + ' - REV - ' + CAST(p.RevisionNum AS VARCHAR(20))
 				ELSE p.PublicationId
 			END AS PublicationId,
 			[p].[PublicationRecordId],
@@ -88,8 +89,8 @@ BEGIN
 
     SELECT DISTINCT
         CASE 
-            WHEN COUNT(*) OVER (PARTITION BY PublicationId) > 1
-                THEN PublicationId + '_' + CAST(RevisionNum AS VARCHAR(20))
+            WHEN COUNT(*) OVER (PARTITION BY PublicationId) > 1 AND NULLIF(LTRIM(RTRIM(RevisionNum)), '') IS NOT NULL
+                THEN PublicationId + ' - REV - ' + CAST(RevisionNum AS VARCHAR(20))
             ELSE PublicationId
         END AS PublicationId,
         PublicationRecordId,


### PR DESCRIPTION
Update USP_GetPartPublications.sql to append ' - REV - {RevisionNum}' to PublicationId. Applied the change in both SELECT blocks for consistent PublicationId formatting and added a changelog entry referencing PN-17478.