### PR TITLE
SPRINT67 - PN-17478 - Include ' - REV - ' in PublicationId when revision exists

### DIFF
--- a/PAS_DB/dbo/Stored Procedures/Procs2/USP_GetPartPublications.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs2/USP_GetPartPublications.sql
@@ -17,6 +17,7 @@
     2    01/07/2025		Devendra Shekh		Allowing to fetch @cmmIds data Despite being Deleted/InActive
     3    11/02/2026		AYUSHI PATEL		Fixed duplicate record issue when applying revisionNumber logic.Moved COUNT() OVER() calculation to outer query after UNION to ensure consistent PublicationId formatting.
 	4    24/07/2026		Vishal Suthar		Added RevNumber by concatenating it in PubId for all the records
+    7    30/07/2026     SUMIT KUMAR      Changed the 'PublicationId' formatting with {Template Description} – REV – {Revision #} if Revision num is there [PN-17478]
  
 --   EXEC [dbo].[USP_GetPartPublications] 102544,1,'711'
      EXEC [dbo].[USP_GetPartPublications] 102544,1,''
@@ -41,7 +42,11 @@ BEGIN
 			--	THEN p.PublicationId + '_' + CAST(p.RevisionNum AS VARCHAR(20))
 			--	ELSE p.PublicationId
 			--END AS PublicationId,
-			p.PublicationId + '_' + CAST(p.RevisionNum AS VARCHAR(20)) AS PublicationId,
+            CASE -- Concate prefix ' - REV - ' with PublicationId if RevisionNum is not null or empty
+				WHEN NULLIF(LTRIM(RTRIM(p.RevisionNum)), '') IS NOT NULL
+				THEN p.PublicationId + ' - REV - ' + CAST(p.RevisionNum AS VARCHAR(20))
+				ELSE p.PublicationId
+			END AS PublicationId,
 			[p].[PublicationRecordId],
 			[p].[ExpirationDate],
 			'' AS [FileName],
@@ -94,7 +99,11 @@ BEGIN
         --        THEN PublicationId + '_' + CAST(RevisionNum AS VARCHAR(20))
         --    ELSE PublicationId
         -- END AS PublicationId,
-		PublicationId + '_' + CAST(RevisionNum AS VARCHAR(20)) AS PublicationId,
+        CASE -- Concate prefix ' - REV - ' with PublicationId if RevisionNum is not null or empty
+            WHEN NULLIF(LTRIM(RTRIM(RevisionNum)), '') IS NOT NULL
+            THEN PublicationId + ' - REV - ' + CAST(RevisionNum AS VARCHAR(20))
+            ELSE PublicationId
+        END AS PublicationId,
         PublicationRecordId,
         ExpirationDate,
         '' AS FileName,


### PR DESCRIPTION
Update USP_GetPartPublications.sql to append ' - REV - {RevisionNum}' to PublicationId. Applied the change in both SELECT blocks for consistent PublicationId formatting and added a changelog entry referencing PN-17478.