### PR TITLE
PN-17518 Sprint 67

### DIFF
--- a/PAS_DB/dbo/Stored Procedures/Procs1/DeleteWOTasksById.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/DeleteWOTasksById.sql
@@ -10,6 +10,7 @@
 ** PR   Date         Author				Change Description
 ** --   --------     -------			----------------------
 	1   07/01/2025   Vishal Suthar		Created
+	2   08/01/2026   SUMIT KUMAR		[PN-17518] Modified to delete related task instructions
 
 EXEC [DeleteWOTasksById] 3
 **************************************************************/
@@ -20,7 +21,20 @@ AS
 	BEGIN TRY
 	BEGIN TRANSACTION
 		
-		DELETE FROM DBO.WorkOrderTaskDetails WHERE WorkOrderTaskId IN (SELECT WorkOrderTaskId FROM WorkOrderTask WHERE WorkOrderPartNumberId = @WOPartNoId);
+		-- Temporary table to hold task IDs for the given Work Order Part Number
+		DECLARE @WOTaskIds TABLE (WorkOrderTaskId BIGINT);
+
+		-- Retrieve all task IDs associated with the specified Work Order Part Number
+		INSERT INTO @WOTaskIds (WorkOrderTaskId)
+		SELECT WorkOrderTaskId FROM DBO.WorkOrderTask WHERE WorkOrderPartNumberId = @WOPartNoId;
+
+		-- Clean up related records from WorkOrderTaskDetails
+		DELETE FROM DBO.WorkOrderTaskDetails WHERE WorkOrderTaskId IN (SELECT WorkOrderTaskId FROM @WOTaskIds);
+		
+		-- Clean up related records from WorkOrderTaskInstruction
+		DELETE FROM DBO.WorkOrderTaskInstruction WHERE WorkOrderTaskId IN (SELECT WorkOrderTaskId FROM @WOTaskIds);
+		
+		-- Delete the parent WorkOrderTask records
 		DELETE FROM DBO.WorkOrderTask WHERE WorkOrderPartNumberId = @WOPartNoId;
 
 	COMMIT TRANSACTION

--- a/PAS_DB/dbo/Stored Procedures/Procs1/DeleteWorkOrderTaskInstruction.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/DeleteWorkOrderTaskInstruction.sql
@@ -13,6 +13,7 @@
 	2   03/21/2025   Ekta Chandegra		Add dbo.USP_AddWorkOrderTaskHistory call to add history
 	3   03/24/2025   Ekta Chandegra		Update IsDeleted value of deleted Work Order Task Instruction in WorkOrderTaskHistory 
 	4   04/29/2025   Ekta Chandegra		Rearrange sequence of remaining instructions after delete
+    5   08/01/2025   SUMIT KUMAR		[PN-17518] Supplied IsFromWorkFlow to USP_InsertWorkOrderTaskInstructionHistory as 0 as it was missing and throughing error
 
 EXEC [DeleteWorkOrderTaskInstruction] 3
 **************************************************************/
@@ -105,7 +106,7 @@ AS
         WHILE @@FETCH_STATUS = 0
         BEGIN
             EXEC dbo.USP_InsertWorkOrderTaskInstructionHistory 
-                @UpdatedInstructionId, @CreatedBy, @InstructionListId, NULL;
+                @UpdatedInstructionId, @CreatedBy, @InstructionListId, NULL, 0;
 
 			EXEC dbo.USP_AddWorkOrderTaskHistory 
                 @WorkOrderTaskId, @CreatedBy, @UpdatedInstructionId, NULL;


### PR DESCRIPTION
Supply the missing IsFromWorkFlow argument (0) to USP_InsertWorkOrderTaskInstructionHistory in DeleteWorkOrderTaskInstruction.sql to prevent errors (PN-17518). Also add a changelog entry recording this fix.

Modified to delete related task instructions as well from all tasks for a WO.