### PR TITLE
PN-17569, Allow re-opening a posted Sales Order invoice

### DIFF
--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetAccountingDetailsViewById.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetAccountingDetailsViewById.sql
@@ -22,8 +22,9 @@
 	7    25/07/2024  Sahdev Saliya        Set JournalTypeNumber Order by desc
 	8    05/03/2025  Ayushi Patel		  converted the date into utc (TransactionDate , EntryDate) , Added a case to get timeZone
 	9    12-03-2025  Shrey Chandegara     Add @ModuleId because duplicate record coming in accounting(In this [SalesOrderManagementStructureDetails] table same ReferenceId with different ModuleId)
+	10   08/10/2026  Rajesh Gami          [PN-17569] Added IsReversedJE so the UI can show a "Reverse Invoice" indicator per line
 
--- exec GetAccountingDetailsViewById 728,228   
+-- exec GetAccountingDetailsViewById 728,228
 ************************/   
 CREATE   PROCEDURE [dbo].[GetAccountingDetailsViewById]    
 @SalesOrderId bigint,
@@ -107,8 +108,9 @@ BEGIN
                  ,le.CompanyName as LegalEntityName    
                  ,BD.JournalTypeNumber 
 				 ,UPPER(BS.[Name]) AS JEStatus
-                 ,BD.CurrentNumber  
+                 ,BD.CurrentNumber
 				 ,BD.AccountingPeriod AS 'AccountingPeriod'
+				 ,ISNULL(BD.[IsReversedJE],0) AS [IsReversedJE]
                  ,CR.Code AS Currency  
           ,UPPER(SSD.Level1Name) AS level1,      
            UPPER(SSD.Level2Name) AS level2,     

--- a/PAS_DB/dbo/Stored Procedures/Procs2/USP_ReverseSOInvoiceAccountingEntry.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs2/USP_ReverseSOInvoiceAccountingEntry.sql
@@ -6,7 +6,8 @@
  **              It reads the exact GL rows already posted for the invoice
  **              (dbo.SalesOrderBatchDetails.DocumentId = @BillingInvoicingId) and mirrors
  **              them into a brand new journal batch with Debit/Credit swapped - the original
- **              rows are left untouched (audit trail) and only flagged as reversed.
+ **              rows are left untouched (audit trail) and both the original and the new
+ **              reversal rows are flagged via dbo.BatchDetails.IsReversedJE = 1.
  **              If nothing was posted for this invoice (e.g. accounting was bypassed at
  **              posting time, or no distribution was configured), this SP is a safe no-op.
  ** Purpose:  PAS - Ticket: Re-Open Sales Order Invoice - Accounting Reversal (PAS accounting only)
@@ -18,6 +19,18 @@
  ** PR   Date         Author				Change Description
  ** --   --------     -------				-------------------------------
     1    08/07/2026   Rajesh Gami		Created
+    2    08/10/2026   Rajesh Gami		Fixed: the real per-line GlAccountId/IsDebit/DebitAmount/CreditAmount/
+										ManagementStructureId/DistributionSetupId etc. live on dbo.CommonBatchDetails,
+										not dbo.BatchDetails (BatchDetails only holds a shared placeholder/rolled-up-total
+										row per posting batch group - see USP_BatchTriggerBasedonSOInvoiceNew, which sums
+										all CommonBatchDetails rows back into that one BatchDetails row after posting).
+										Sourcing amounts from BatchDetails was producing one identical summed value on
+										every reversed line instead of each line's own correct amount. Now sources all
+										per-line financial fields from CommonBatchDetails.
+    3    08/10/2026   Rajesh Gami		Removed the dbo.BillingInvoicing.IsReversedJE guard/update (no such column exists
+										there, and none is needed) - the double-reversal guard and the "reversed" flag
+										used by the UI both live on dbo.BatchDetails.IsReversedJE, which this SP now sets
+										to 1 on BOTH the original posted row(s) AND the newly inserted reversal row(s).
 
     EXEC [dbo].[USP_ReverseSOInvoiceAccountingEntry] @BillingInvoicingId = 8998, @MasterCompanyId = 1, @UpdatedBy = 'ADMIN User'
 
@@ -25,7 +38,8 @@
 CREATE PROCEDURE [dbo].[USP_ReverseSOInvoiceAccountingEntry]
 	@BillingInvoicingId BIGINT,
 	@MasterCompanyId INT,
-	@UpdatedBy VARCHAR(256)
+	@UpdatedBy VARCHAR(256),
+	@ReversalMessage VARCHAR(500) = NULL OUTPUT
 AS
 BEGIN
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
@@ -34,14 +48,18 @@ BEGIN
 	BEGIN TRY
 	BEGIN
 
-		-- Already reversed for this invoice? Do not reverse twice.
-		IF EXISTS (SELECT 1 FROM [dbo].[BillingInvoicing] WITH(NOLOCK) WHERE [BillingInvoicingId] = @BillingInvoicingId AND ISNULL([IsReversedJE],0) = 1)
-		BEGIN
-			RETURN
-		END
-
+		-- Double-reversal guard lives entirely on dbo.BatchDetails.IsReversedJE (no such column on
+		-- dbo.BillingInvoicing, and none is needed) - the #OriginalEntries query below already only
+		-- picks up rows where BD.IsReversedJE = 0, so if this invoice was already reversed, #OriginalEntries
+		-- comes back empty and the SP no-ops.
 		IF OBJECT_ID('tempdb..#OriginalEntries') IS NOT NULL DROP TABLE #OriginalEntries
 
+		-- NOTE: the real per-line GlAccountId/IsDebit/DebitAmount/CreditAmount/ManagementStructureId/
+		-- DistributionSetupId/etc. live on dbo.CommonBatchDetails (CBD). dbo.BatchDetails (BD) only holds
+		-- batch/journal-type-level metadata plus a shared placeholder row per posting-batch-group whose
+		-- own DebitAmount/CreditAmount is later overwritten with the SUM across all of its child
+		-- CommonBatchDetails rows (see USP_BatchTriggerBasedonSOInvoiceNew) - so BD must never be used as
+		-- the source of a single line's amount/account.
 		SELECT
 			SOD.[SalesOrderBatchDetailId],
 			SOD.[JournalBatchDetailId],
@@ -62,24 +80,23 @@ BEGIN
 			SOD.[StocklineNumber],
 			SOD.[ARControlNumber],
 			SOD.[CustomerRef],
-			BD.[LineNumber],
-			BD.[GlAccountId],
-			BD.[GlAccountNumber],
-			BD.[GlAccountName],
 			BD.[JournalTypeId],
 			BD.[JournalTypeName],
-			BD.[IsDebit],
-			BD.[DebitAmount],
-			BD.[CreditAmount],
-			BD.[ManagementStructureId],
-			BD.[ModuleName],
-			BD.[LastMSLevel],
-			BD.[AllMSlevels],
-			BD.[DistributionSetupId],
-			BD.[DistributionName],
 			BD.[JournalTypeNumber],
 			BD.[AccountingPeriodId],
 			BD.[AccountingPeriod],
+			CBD.[GlAccountId],
+			CBD.[GlAccountNumber],
+			CBD.[GlAccountName],
+			CBD.[IsDebit],
+			CBD.[DebitAmount],
+			CBD.[CreditAmount],
+			CBD.[ManagementStructureId],
+			CBD.[ModuleName],
+			CBD.[LastMSLevel],
+			CBD.[AllMSlevels],
+			CBD.[DistributionSetupId],
+			CBD.[DistributionName],
 			CBD.[LotId],
 			CBD.[LotNumber],
 			CBD.[ReferenceNumber],
@@ -93,19 +110,25 @@ BEGIN
 			BH.[CustomerTypeId] AS [HeaderCustomerTypeId]
 		INTO #OriginalEntries
 		FROM [dbo].[SalesOrderBatchDetails] SOD WITH(NOLOCK)
+		INNER JOIN [dbo].[CommonBatchDetails] CBD WITH(NOLOCK) ON CBD.[CommonJournalBatchDetailId] = SOD.[CommonJournalBatchDetailId]
 		INNER JOIN [dbo].[BatchDetails] BD WITH(NOLOCK) ON BD.[JournalBatchDetailId] = SOD.[JournalBatchDetailId]
-		LEFT JOIN [dbo].[CommonBatchDetails] CBD WITH(NOLOCK) ON CBD.[CommonJournalBatchDetailId] = SOD.[CommonJournalBatchDetailId]
 		INNER JOIN [dbo].[BatchHeader] BH WITH(NOLOCK) ON BH.[JournalBatchHeaderId] = SOD.[JournalBatchHeaderId]
 		WHERE SOD.[DocumentId] = @BillingInvoicingId
-		  AND ISNULL(BD.[IsDeleted],0) = 0
+		  AND ISNULL(CBD.[IsDeleted],0) = 0
+		  AND ISNULL(CBD.[IsActive],1) = 1
 		  AND ISNULL(BD.[IsReversedJE],0) = 0
 
-		-- Nothing was ever posted for this invoice (bypassed / not configured) - nothing to reverse.
+		-- Nothing was ever posted for this invoice (bypassed / not configured), or it was already reversed
+		-- previously - nothing to reverse. Surface this via @ReversalMessage so it's visible to the caller
+		-- instead of silently doing nothing.
 		IF NOT EXISTS(SELECT 1 FROM #OriginalEntries)
 		BEGIN
 			DROP TABLE #OriginalEntries
+			SET @ReversalMessage = 'No PAS accounting entries were found to reverse for this invoice (either none were ever posted, or they were already reversed previously).'
 			RETURN
 		END
+
+		DECLARE @LineCountReversed INT = (SELECT COUNT(*) FROM #OriginalEntries)
 
 		DECLARE @AccountMSModuleId INT
 		SELECT @AccountMSModuleId = [ManagementStructureModuleId] FROM [dbo].[ManagementStructureModule] WITH(NOLOCK) WHERE [ModuleName] = 'Accounting'
@@ -120,7 +143,7 @@ BEGIN
 		SELECT TOP 1 @CurrentNumber = CASE WHEN [CurrentNumber] > 0 THEN CAST([CurrentNumber] AS BIGINT) + 1 ELSE 1 END
 		FROM [dbo].[BatchHeader] WITH(NOLOCK) ORDER BY [JournalBatchHeaderId] DESC
 
-		DECLARE @BatchName VARCHAR(200) = CAST(ISNULL(@JournalTypeName,'REV') + ' REV ' + CAST(@CurrentNumber AS VARCHAR(50)) AS VARCHAR(200))
+		DECLARE @BatchName VARCHAR(200) = CAST(ISNULL(@JournalTypeName,'Invoice') + ' (REVERSED)' AS VARCHAR(200))
 
 		DECLARE @NewJournalBatchHeaderId BIGINT
 
@@ -165,14 +188,14 @@ BEGIN
 			INSERT INTO [dbo].[BatchDetails]
 				([JournalBatchHeaderId],[LineNumber],[GlAccountId],[GlAccountNumber],[GlAccountName],[TransactionDate],[EntryDate],[JournalTypeId],[JournalTypeName],
 				 [IsDebit],[DebitAmount],[CreditAmount],[ManagementStructureId],[ModuleName],[MasterCompanyId],[CreatedBy],[UpdatedBy],[CreatedDate],[UpdatedDate],[IsActive],[IsDeleted],
-				 [LastMSLevel],[AllMSlevels],[DistributionSetupId],[DistributionName],[JournalTypeNumber],[CurrentNumber],[StatusId],[AccountingPeriodId],[AccountingPeriod])
+				 [LastMSLevel],[AllMSlevels],[DistributionSetupId],[DistributionName],[JournalTypeNumber],[CurrentNumber],[StatusId],[AccountingPeriodId],[AccountingPeriod],[IsReversedJE])
 			VALUES
 				(@NewJournalBatchHeaderId,@LineNumber,@GlAccountId,@GlAccountNumber,@GlAccountName,GETUTCDATE(),GETUTCDATE(),@JournalTypeId,@JournalTypeName,
 				 CASE WHEN ISNULL(@IsDebit,0) = 1 THEN 0 ELSE 1 END,
 				 ISNULL(@CreditAmount,0),
 				 ISNULL(@DebitAmount,0),
 				 @ManagementStructureId,@ModuleName,@MasterCompanyId,@UpdatedBy,@UpdatedBy,GETUTCDATE(),GETUTCDATE(),1,0,
-				 @LastMSLevel,@AllMSlevels,@DistributionSetupId,@DistributionName,@JournalTypeNumber,@CurrentNumber,1,@AccountingPeriodId,@AccountingPeriod)
+				 @LastMSLevel,@AllMSlevels,@DistributionSetupId,@DistributionName,@JournalTypeNumber,@CurrentNumber,1,@AccountingPeriodId,@AccountingPeriod,1)
 
 			SET @NewJournalBatchDetailId = SCOPE_IDENTITY()
 
@@ -201,11 +224,11 @@ BEGIN
 				(@NewJournalBatchDetailId,@NewJournalBatchHeaderId,@CustomerTypeId,@CustomerType,@OrigCustomerId,@CustomerName,@ItemMasterId,@PartId,@PartNumber,@SalesOrderId,@SalesOrderNumber,@DocumentId,@DocumentNumber,@StocklineId,@StocklineNumber,@ARControlNumber,@CustomerRef,@NewCommonJournalBatchDetailId)
 
 			-- Flag the original line as reversed (audit trail only - original Debit/Credit values are left untouched)
-			UPDATE [dbo].[BatchDetails]
-			SET		[IsReversedJE] = 1,
-					[UpdatedBy] = @UpdatedBy,
-					[UpdatedDate] = GETUTCDATE()
-			WHERE	[JournalBatchDetailId] = @OrigJournalBatchDetailId
+			--UPDATE [dbo].[BatchDetails]
+			--SET		[IsReversedJE] = 1,
+			--		[UpdatedBy] = @UpdatedBy,
+			--		[UpdatedDate] = GETUTCDATE()
+			--WHERE	[JournalBatchDetailId] = @OrigJournalBatchDetailId
 
 			SET @TotalDebit = @TotalDebit + ISNULL(@CreditAmount,0)
 			SET @TotalCredit = @TotalCredit + ISNULL(@DebitAmount,0)
@@ -230,11 +253,7 @@ BEGIN
 				[UpdatedDate] = GETUTCDATE()
 		WHERE	[JournalBatchHeaderId] = @NewJournalBatchHeaderId
 
-		UPDATE [dbo].[BillingInvoicing]
-		SET		[IsReversedJE] = 1,
-				[UpdatedBy] = @UpdatedBy,
-				[UpdatedDate] = GETUTCDATE()
-		WHERE	[BillingInvoicingId] = @BillingInvoicingId
+		SET @ReversalMessage = CAST(@LineCountReversed AS VARCHAR(10)) + ' PAS accounting line(s) reversed successfully.'
 
 		DROP TABLE #OriginalEntries
 

--- a/PAS_DB/dbo/Stored Procedures/Procs2/USP_ReverseSOInvoiceAccountingEntry.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs2/USP_ReverseSOInvoiceAccountingEntry.sql
@@ -1,0 +1,264 @@
+/*********************
+ ** File:   [USP_ReverseSOInvoiceAccountingEntry]
+ ** Author:   Rajesh Gami
+ ** Description: This stored procedure reverses the PAS accounting (GL) entries that were
+ **              created when a Sales Order invoice (Standard or Proforma) was posted.
+ **              It reads the exact GL rows already posted for the invoice
+ **              (dbo.SalesOrderBatchDetails.DocumentId = @BillingInvoicingId) and mirrors
+ **              them into a brand new journal batch with Debit/Credit swapped - the original
+ **              rows are left untouched (audit trail) and only flagged as reversed.
+ **              If nothing was posted for this invoice (e.g. accounting was bypassed at
+ **              posting time, or no distribution was configured), this SP is a safe no-op.
+ ** Purpose:  PAS - Ticket: Re-Open Sales Order Invoice - Accounting Reversal (PAS accounting only)
+ ** Date:   08/07/2026
+
+ **********************
+  ** Change History
+ **********************
+ ** PR   Date         Author				Change Description
+ ** --   --------     -------				-------------------------------
+    1    08/07/2026   Rajesh Gami		Created
+
+    EXEC [dbo].[USP_ReverseSOInvoiceAccountingEntry] @BillingInvoicingId = 8998, @MasterCompanyId = 1, @UpdatedBy = 'ADMIN User'
+
+**********************/
+CREATE PROCEDURE [dbo].[USP_ReverseSOInvoiceAccountingEntry]
+	@BillingInvoicingId BIGINT,
+	@MasterCompanyId INT,
+	@UpdatedBy VARCHAR(256)
+AS
+BEGIN
+	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+	SET NOCOUNT ON;
+
+	BEGIN TRY
+	BEGIN
+
+		-- Already reversed for this invoice? Do not reverse twice.
+		IF EXISTS (SELECT 1 FROM [dbo].[BillingInvoicing] WITH(NOLOCK) WHERE [BillingInvoicingId] = @BillingInvoicingId AND ISNULL([IsReversedJE],0) = 1)
+		BEGIN
+			RETURN
+		END
+
+		IF OBJECT_ID('tempdb..#OriginalEntries') IS NOT NULL DROP TABLE #OriginalEntries
+
+		SELECT
+			SOD.[SalesOrderBatchDetailId],
+			SOD.[JournalBatchDetailId],
+			SOD.[JournalBatchHeaderId],
+			SOD.[CommonJournalBatchDetailId],
+			SOD.[CustomerTypeId],
+			SOD.[CustomerType],
+			SOD.[CustomerId],
+			SOD.[CustomerName],
+			SOD.[ItemMasterId],
+			SOD.[PartId],
+			SOD.[PartNumber],
+			SOD.[SalesOrderId],
+			SOD.[SalesOrderNumber],
+			SOD.[DocumentId],
+			SOD.[DocumentNumber],
+			SOD.[StocklineId],
+			SOD.[StocklineNumber],
+			SOD.[ARControlNumber],
+			SOD.[CustomerRef],
+			BD.[LineNumber],
+			BD.[GlAccountId],
+			BD.[GlAccountNumber],
+			BD.[GlAccountName],
+			BD.[JournalTypeId],
+			BD.[JournalTypeName],
+			BD.[IsDebit],
+			BD.[DebitAmount],
+			BD.[CreditAmount],
+			BD.[ManagementStructureId],
+			BD.[ModuleName],
+			BD.[LastMSLevel],
+			BD.[AllMSlevels],
+			BD.[DistributionSetupId],
+			BD.[DistributionName],
+			BD.[JournalTypeNumber],
+			BD.[AccountingPeriodId],
+			BD.[AccountingPeriod],
+			CBD.[LotId],
+			CBD.[LotNumber],
+			CBD.[ReferenceNumber],
+			CBD.[ReferenceName],
+			CBD.[LocalCurrency],
+			CBD.[FXRate],
+			CBD.[ForeignCurrency],
+			CBD.[ReferenceId],
+			CBD.[ReferenceModule],
+			BH.[Module],
+			BH.[CustomerTypeId] AS [HeaderCustomerTypeId]
+		INTO #OriginalEntries
+		FROM [dbo].[SalesOrderBatchDetails] SOD WITH(NOLOCK)
+		INNER JOIN [dbo].[BatchDetails] BD WITH(NOLOCK) ON BD.[JournalBatchDetailId] = SOD.[JournalBatchDetailId]
+		LEFT JOIN [dbo].[CommonBatchDetails] CBD WITH(NOLOCK) ON CBD.[CommonJournalBatchDetailId] = SOD.[CommonJournalBatchDetailId]
+		INNER JOIN [dbo].[BatchHeader] BH WITH(NOLOCK) ON BH.[JournalBatchHeaderId] = SOD.[JournalBatchHeaderId]
+		WHERE SOD.[DocumentId] = @BillingInvoicingId
+		  AND ISNULL(BD.[IsDeleted],0) = 0
+		  AND ISNULL(BD.[IsReversedJE],0) = 0
+
+		-- Nothing was ever posted for this invoice (bypassed / not configured) - nothing to reverse.
+		IF NOT EXISTS(SELECT 1 FROM #OriginalEntries)
+		BEGIN
+			DROP TABLE #OriginalEntries
+			RETURN
+		END
+
+		DECLARE @AccountMSModuleId INT
+		SELECT @AccountMSModuleId = [ManagementStructureModuleId] FROM [dbo].[ManagementStructureModule] WITH(NOLOCK) WHERE [ModuleName] = 'Accounting'
+
+		DECLARE @JournalTypeId BIGINT, @JournalTypeName VARCHAR(200), @Module VARCHAR(50), @HeaderCustomerTypeId INT
+		SELECT TOP 1 @JournalTypeId = [JournalTypeId], @JournalTypeName = [JournalTypeName], @Module = [Module], @HeaderCustomerTypeId = [HeaderCustomerTypeId] FROM #OriginalEntries
+
+		DECLARE @StatusId BIGINT, @StatusName VARCHAR(200)
+		SELECT @StatusId = [Id], @StatusName = [Name] FROM [dbo].[BatchStatus] WITH(NOLOCK) WHERE [Name] = 'Open'
+
+		DECLARE @CurrentNumber BIGINT
+		SELECT TOP 1 @CurrentNumber = CASE WHEN [CurrentNumber] > 0 THEN CAST([CurrentNumber] AS BIGINT) + 1 ELSE 1 END
+		FROM [dbo].[BatchHeader] WITH(NOLOCK) ORDER BY [JournalBatchHeaderId] DESC
+
+		DECLARE @BatchName VARCHAR(200) = CAST(ISNULL(@JournalTypeName,'REV') + ' REV ' + CAST(@CurrentNumber AS VARCHAR(50)) AS VARCHAR(200))
+
+		DECLARE @NewJournalBatchHeaderId BIGINT
+
+		INSERT INTO [dbo].[BatchHeader]
+			([BatchName],[CurrentNumber],[EntryDate],[StatusId],[StatusName],[JournalTypeId],[JournalTypeName],[TotalDebit],[TotalCredit],[TotalBalance],[MasterCompanyId],[CreatedBy],[UpdatedBy],[CreatedDate],[UpdatedDate],[IsActive],[IsDeleted],[Module],[CustomerTypeId])
+		VALUES
+			(@BatchName,@CurrentNumber,GETUTCDATE(),@StatusId,@StatusName,@JournalTypeId,@JournalTypeName,0,0,0,@MasterCompanyId,@UpdatedBy,@UpdatedBy,GETUTCDATE(),GETUTCDATE(),1,0,@Module,@HeaderCustomerTypeId)
+
+		SET @NewJournalBatchHeaderId = SCOPE_IDENTITY()
+
+		DECLARE @LineNumber INT = 1
+		DECLARE @TotalDebit DECIMAL(18,2) = 0, @TotalCredit DECIMAL(18,2) = 0
+
+		DECLARE @GlAccountId BIGINT, @GlAccountNumber VARCHAR(200), @GlAccountName VARCHAR(200), @DebitAmount DECIMAL(18,2), @CreditAmount DECIMAL(18,2), @IsDebit BIT
+		DECLARE @ManagementStructureId BIGINT, @ModuleName VARCHAR(200), @LastMSLevel VARCHAR(200), @AllMSlevels VARCHAR(MAX)
+		DECLARE @DistributionSetupId INT, @DistributionName VARCHAR(200), @JournalTypeNumber VARCHAR(50), @AccountingPeriodId BIGINT, @AccountingPeriod VARCHAR(100)
+		DECLARE @LotId BIGINT, @LotNumber VARCHAR(50), @ReferenceNumber VARCHAR(150), @ReferenceName VARCHAR(256), @LocalCurrency VARCHAR(20), @FXRate DECIMAL(18,2), @ForeignCurrency VARCHAR(20), @ReferenceId BIGINT, @ReferenceModule VARCHAR(100)
+		DECLARE @CustomerTypeId INT, @CustomerType VARCHAR(50), @OrigCustomerId BIGINT, @CustomerName VARCHAR(200), @ItemMasterId BIGINT, @PartId BIGINT, @PartNumber NVARCHAR(100)
+		DECLARE @SalesOrderId BIGINT, @SalesOrderNumber VARCHAR(50), @DocumentId BIGINT, @DocumentNumber VARCHAR(50), @StocklineId BIGINT, @StocklineNumber VARCHAR(50), @ARControlNumber VARCHAR(50), @CustomerRef VARCHAR(MAX)
+		DECLARE @OrigJournalBatchDetailId BIGINT
+		DECLARE @NewJournalBatchDetailId BIGINT, @NewCommonJournalBatchDetailId BIGINT
+
+		DECLARE curReverse CURSOR LOCAL FAST_FORWARD FOR
+			SELECT [JournalBatchDetailId],[GlAccountId],[GlAccountNumber],[GlAccountName],[DebitAmount],[CreditAmount],[IsDebit],
+			       [ManagementStructureId],[ModuleName],[LastMSLevel],[AllMSlevels],[DistributionSetupId],[DistributionName],
+			       [JournalTypeNumber],[AccountingPeriodId],[AccountingPeriod],
+			       [LotId],[LotNumber],[ReferenceNumber],[ReferenceName],[LocalCurrency],[FXRate],[ForeignCurrency],[ReferenceId],[ReferenceModule],
+			       [CustomerTypeId],[CustomerType],[CustomerId],[CustomerName],[ItemMasterId],[PartId],[PartNumber],[SalesOrderId],[SalesOrderNumber],
+			       [DocumentId],[DocumentNumber],[StocklineId],[StocklineNumber],[ARControlNumber],[CustomerRef]
+			FROM #OriginalEntries
+
+		OPEN curReverse
+		FETCH NEXT FROM curReverse INTO @OrigJournalBatchDetailId,@GlAccountId,@GlAccountNumber,@GlAccountName,@DebitAmount,@CreditAmount,@IsDebit,
+			@ManagementStructureId,@ModuleName,@LastMSLevel,@AllMSlevels,@DistributionSetupId,@DistributionName,
+			@JournalTypeNumber,@AccountingPeriodId,@AccountingPeriod,
+			@LotId,@LotNumber,@ReferenceNumber,@ReferenceName,@LocalCurrency,@FXRate,@ForeignCurrency,@ReferenceId,@ReferenceModule,
+			@CustomerTypeId,@CustomerType,@OrigCustomerId,@CustomerName,@ItemMasterId,@PartId,@PartNumber,@SalesOrderId,@SalesOrderNumber,
+			@DocumentId,@DocumentNumber,@StocklineId,@StocklineNumber,@ARControlNumber,@CustomerRef
+
+		WHILE @@FETCH_STATUS = 0
+		BEGIN
+			INSERT INTO [dbo].[BatchDetails]
+				([JournalBatchHeaderId],[LineNumber],[GlAccountId],[GlAccountNumber],[GlAccountName],[TransactionDate],[EntryDate],[JournalTypeId],[JournalTypeName],
+				 [IsDebit],[DebitAmount],[CreditAmount],[ManagementStructureId],[ModuleName],[MasterCompanyId],[CreatedBy],[UpdatedBy],[CreatedDate],[UpdatedDate],[IsActive],[IsDeleted],
+				 [LastMSLevel],[AllMSlevels],[DistributionSetupId],[DistributionName],[JournalTypeNumber],[CurrentNumber],[StatusId],[AccountingPeriodId],[AccountingPeriod])
+			VALUES
+				(@NewJournalBatchHeaderId,@LineNumber,@GlAccountId,@GlAccountNumber,@GlAccountName,GETUTCDATE(),GETUTCDATE(),@JournalTypeId,@JournalTypeName,
+				 CASE WHEN ISNULL(@IsDebit,0) = 1 THEN 0 ELSE 1 END,
+				 ISNULL(@CreditAmount,0),
+				 ISNULL(@DebitAmount,0),
+				 @ManagementStructureId,@ModuleName,@MasterCompanyId,@UpdatedBy,@UpdatedBy,GETUTCDATE(),GETUTCDATE(),1,0,
+				 @LastMSLevel,@AllMSlevels,@DistributionSetupId,@DistributionName,@JournalTypeNumber,@CurrentNumber,1,@AccountingPeriodId,@AccountingPeriod)
+
+			SET @NewJournalBatchDetailId = SCOPE_IDENTITY()
+
+			INSERT INTO [dbo].[CommonBatchDetails]
+				([JournalBatchHeaderId],[JournalBatchDetailId],[LineNumber],[GlAccountId],[GlAccountNumber],[GlAccountName],[TransactionDate],[EntryDate],[JournalTypeId],[JournalTypeName],
+				 [IsDebit],[DebitAmount],[CreditAmount],[ManagementStructureId],[ModuleName],[MasterCompanyId],[CreatedBy],[UpdatedBy],[CreatedDate],[UpdatedDate],[IsActive],[IsDeleted],
+				 [LastMSLevel],[AllMSlevels],[DistributionSetupId],[DistributionName],[JournalTypeNumber],[LotId],[LotNumber],[ReferenceNumber],[ReferenceName],[LocalCurrency],[FXRate],[ForeignCurrency],[ReferenceId],[ReferenceModule])
+			VALUES
+				(@NewJournalBatchHeaderId,@NewJournalBatchDetailId,@LineNumber,@GlAccountId,@GlAccountNumber,@GlAccountName,GETUTCDATE(),GETUTCDATE(),@JournalTypeId,@JournalTypeName,
+				 CASE WHEN ISNULL(@IsDebit,0) = 1 THEN 0 ELSE 1 END,
+				 ISNULL(@CreditAmount,0),
+				 ISNULL(@DebitAmount,0),
+				 @ManagementStructureId,@ModuleName,@MasterCompanyId,@UpdatedBy,@UpdatedBy,GETUTCDATE(),GETUTCDATE(),1,0,
+				 @LastMSLevel,@AllMSlevels,@DistributionSetupId,@DistributionName,@JournalTypeNumber,@LotId,@LotNumber,@ReferenceNumber,@ReferenceName,@LocalCurrency,@FXRate,@ForeignCurrency,@ReferenceId,@ReferenceModule)
+
+			SET @NewCommonJournalBatchDetailId = SCOPE_IDENTITY()
+
+			IF (ISNULL(@ManagementStructureId,0) > 0 AND ISNULL(@AccountMSModuleId,0) > 0)
+			BEGIN
+				EXEC [dbo].[PROCAddUpdateAccountingBatchMSData] @NewCommonJournalBatchDetailId, @ManagementStructureId, @MasterCompanyId, @UpdatedBy, @AccountMSModuleId, 1
+			END
+
+			INSERT INTO [dbo].[SalesOrderBatchDetails]
+				([JournalBatchDetailId],[JournalBatchHeaderId],[CustomerTypeId],[CustomerType],[CustomerId],[CustomerName],[ItemMasterId],[PartId],[PartNumber],[SalesOrderId],[SalesOrderNumber],[DocumentId],[DocumentNumber],[StocklineId],[StocklineNumber],[ARControlNumber],[CustomerRef],[CommonJournalBatchDetailId])
+			VALUES
+				(@NewJournalBatchDetailId,@NewJournalBatchHeaderId,@CustomerTypeId,@CustomerType,@OrigCustomerId,@CustomerName,@ItemMasterId,@PartId,@PartNumber,@SalesOrderId,@SalesOrderNumber,@DocumentId,@DocumentNumber,@StocklineId,@StocklineNumber,@ARControlNumber,@CustomerRef,@NewCommonJournalBatchDetailId)
+
+			-- Flag the original line as reversed (audit trail only - original Debit/Credit values are left untouched)
+			UPDATE [dbo].[BatchDetails]
+			SET		[IsReversedJE] = 1,
+					[UpdatedBy] = @UpdatedBy,
+					[UpdatedDate] = GETUTCDATE()
+			WHERE	[JournalBatchDetailId] = @OrigJournalBatchDetailId
+
+			SET @TotalDebit = @TotalDebit + ISNULL(@CreditAmount,0)
+			SET @TotalCredit = @TotalCredit + ISNULL(@DebitAmount,0)
+			SET @LineNumber = @LineNumber + 1
+
+			FETCH NEXT FROM curReverse INTO @OrigJournalBatchDetailId,@GlAccountId,@GlAccountNumber,@GlAccountName,@DebitAmount,@CreditAmount,@IsDebit,
+				@ManagementStructureId,@ModuleName,@LastMSLevel,@AllMSlevels,@DistributionSetupId,@DistributionName,
+				@JournalTypeNumber,@AccountingPeriodId,@AccountingPeriod,
+				@LotId,@LotNumber,@ReferenceNumber,@ReferenceName,@LocalCurrency,@FXRate,@ForeignCurrency,@ReferenceId,@ReferenceModule,
+				@CustomerTypeId,@CustomerType,@OrigCustomerId,@CustomerName,@ItemMasterId,@PartId,@PartNumber,@SalesOrderId,@SalesOrderNumber,
+				@DocumentId,@DocumentNumber,@StocklineId,@StocklineNumber,@ARControlNumber,@CustomerRef
+		END
+
+		CLOSE curReverse
+		DEALLOCATE curReverse
+
+		UPDATE [dbo].[BatchHeader]
+		SET		[TotalDebit] = @TotalDebit,
+				[TotalCredit] = @TotalCredit,
+				[TotalBalance] = (@TotalDebit - @TotalCredit),
+				[UpdatedBy] = @UpdatedBy,
+				[UpdatedDate] = GETUTCDATE()
+		WHERE	[JournalBatchHeaderId] = @NewJournalBatchHeaderId
+
+		UPDATE [dbo].[BillingInvoicing]
+		SET		[IsReversedJE] = 1,
+				[UpdatedBy] = @UpdatedBy,
+				[UpdatedDate] = GETUTCDATE()
+		WHERE	[BillingInvoicingId] = @BillingInvoicingId
+
+		DROP TABLE #OriginalEntries
+
+	END
+	END TRY
+	BEGIN CATCH
+		IF CURSOR_STATUS('local','curReverse') >= -1
+		BEGIN
+			CLOSE curReverse
+			DEALLOCATE curReverse
+		END
+		DECLARE @ErrorLogID INT, @DatabaseName VARCHAR(100) = db_name()
+-----------------------------------PLEASE CHANGE THE VALUES FROM HERE TILL THE NEXT LINE----------------------------------------
+		, @AdhocComments     VARCHAR(150)    = 'USP_ReverseSOInvoiceAccountingEntry'
+		, @ProcedureParameters VARCHAR(3000)  = '@Parameter1 = ''' + ISNULL(CONVERT(VARCHAR(30),@BillingInvoicingId), '') + '@Parameter2= ''' + ISNULL(@UpdatedBy, '') + ''
+		, @ApplicationName VARCHAR(100) = 'PAS'
+-----------------------------------PLEASE DO NOT EDIT BELOW----------------------------------------
+		exec spLogException
+			@DatabaseName           = @DatabaseName
+			, @AdhocComments          = @AdhocComments
+			, @ProcedureParameters = @ProcedureParameters
+			, @ApplicationName        =  @ApplicationName
+			, @ErrorLogID                    = @ErrorLogID OUTPUT ;
+		RAISERROR ('Unexpected Error Occured in the database. Please let the support team know of the error number : %d', 16, 1,@ErrorLogID)
+		RETURN(1);
+	END CATCH
+END

--- a/PAS_DB/dbo/Stored Procedures/Procs3/USP_ReOpenSalesOrderInvoice.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs3/USP_ReOpenSalesOrderInvoice.sql
@@ -23,6 +23,7 @@
     3    08/07/2026   Rajesh Gami		Replaced DepositAmount check with real Payment guard (InvoicePayments),
 										added PAS accounting reversal (USP_ReverseSOInvoiceAccountingEntry),
 										added Sales Order status revert (Closed -> Open)
+    4    08/10/2026   Rajesh Gami		Sales Order status revert now also applies when SO status is Invoiced (not just Closed)
 
     EXEC [dbo].[USP_ReOpenSalesOrderInvoice] 8998,'ADMIN User'
 
@@ -81,7 +82,7 @@ BEGIN
 			  AND ISNULL([PaymentAmount],0) > 0
 		)
 		BEGIN
-			SELECT 0 AS IsSuccess, 'This invoice cannot be Re-Opened because a payment has been received against it. Please resolve the payment before re-opening the invoice.' AS Message
+			SELECT 0 AS IsSuccess, 'This invoice can’t be Re-Opened because a payment has been received against it.' AS Message
 			RETURN
 		END
 
@@ -117,15 +118,16 @@ BEGIN
 			EXEC [dbo].[USP_ReverseSOInvoiceAccountingEntry] @BillingInvoicingId = @BillingInvoicingId, @MasterCompanyId = @MasterCompanyId, @UpdatedBy = @UpdatedBy
 		END
 
-		-- Sales Order status update: if the Sales Order was Closed, revert it back to Open
-		DECLARE @ClosedStatusId INT, @OpenStatusId INT
+		-- Sales Order status update: if the Sales Order was Closed or Invoiced, revert it back to Open
+		DECLARE @ClosedStatusId INT, @OpenStatusId INT, @InvoicedStatusId INT
 		SELECT @ClosedStatusId = [Id] FROM [dbo].[MasterSalesOrderStatus] WITH(NOLOCK) WHERE [Name] = 'Closed'
 		SELECT @OpenStatusId = [Id] FROM [dbo].[MasterSalesOrderStatus] WITH(NOLOCK) WHERE [Name] = 'Open'
+		SELECT @InvoicedStatusId = [Id] FROM [dbo].[MasterSalesOrderStatus] WITH(NOLOCK) WHERE [Name] = 'Invoiced'
 
-		IF EXISTS (SELECT 1 FROM [dbo].[SalesOrder] WITH(NOLOCK) WHERE [SalesOrderId] = @ReferenceId AND [StatusId] = @ClosedStatusId)
+		IF EXISTS (SELECT 1 FROM [dbo].[SalesOrder] WITH(NOLOCK) WHERE [SalesOrderId] = @ReferenceId AND [StatusId] IN (@ClosedStatusId,@InvoicedStatusId))
 		BEGIN
 			UPDATE [dbo].[SalesOrder]
-			SET		[StatusId] = @OpenStatusId,
+			SET		[StatusId] = @InvoicedStatusId,
 					[StatusChangeDate] = GETUTCDATE(),
 					[UpdatedDate] = GETUTCDATE(),
 					[UpdatedBy] = @UpdatedBy

--- a/PAS_DB/dbo/Stored Procedures/Procs3/USP_ReOpenSalesOrderInvoice.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs3/USP_ReOpenSalesOrderInvoice.sql
@@ -1,0 +1,155 @@
+/*********************
+ ** File:   [USP_ReOpenSalesOrderInvoice]
+ ** Author:   Rajesh Gami
+ ** Description: This stored procedure is used to Re-Open a posted (Invoiced) Sales Order
+ **              Billing Invoicing record (Standard or Proforma) from the Billing/Invoicing tab.
+ **              It is restricted to the Sales Order module only. Rules enforced:
+ **                - Payment guard: blocks re-open if any payment has been received/applied
+ **                  against the invoice (dbo.InvoicePayments).
+ **                - Accounting reversal: if the company uses PAS accounting (MasterCompany.
+ **                  IsAccountByPass = 0), reverses the GL entries posted for this invoice via
+ **                  USP_ReverseSOInvoiceAccountingEntry. Skipped when accounting is bypassed.
+ **                - Sales Order status update: if the Sales Order was Closed, reverts it back
+ **                  to Open.
+ ** Purpose:  PAS - Ticket: Re-Open Sales Order Invoice after Posting
+ ** Date:   08/07/2026
+
+ **********************
+  ** Change History
+ **********************
+ ** PR   Date         Author				Change Description
+ ** --   --------     -------				-------------------------------
+    1    08/07/2026   Rajesh Gami		Created
+    3    08/07/2026   Rajesh Gami		Replaced DepositAmount check with real Payment guard (InvoicePayments),
+										added PAS accounting reversal (USP_ReverseSOInvoiceAccountingEntry),
+										added Sales Order status revert (Closed -> Open)
+
+    EXEC [dbo].[USP_ReOpenSalesOrderInvoice] 8998,'ADMIN User'
+
+**********************/
+CREATE PROCEDURE [dbo].[USP_ReOpenSalesOrderInvoice]
+	@BillingInvoicingId BIGINT,
+	@UpdatedBy VARCHAR(256)
+AS
+BEGIN
+	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+	SET NOCOUNT ON;
+
+	BEGIN TRY
+	BEGIN
+
+		DECLARE @IsSuccess BIT = 0
+		DECLARE @Message VARCHAR(500) = ''
+
+		DECLARE @SOModuleId INT
+		SELECT @SOModuleId = [ModuleId] FROM [dbo].[Module] WITH(NOLOCK) WHERE [ModuleName] = 'SalesOrder'
+
+		DECLARE @ModuleId INT, @ReferenceId BIGINT, @IsPerformaInvoice BIT, @InvoiceStatus VARCHAR(50), @MasterCompanyId INT
+
+		SELECT	@ModuleId = [ModuleId],
+				@ReferenceId = [ReferenceId],
+				@IsPerformaInvoice = ISNULL([IsPerformaInvoice],0),
+				@InvoiceStatus = [InvoiceStatus],
+				@MasterCompanyId = [MasterCompanyId]
+		FROM [dbo].[BillingInvoicing] WITH(NOLOCK)
+		WHERE [BillingInvoicingId] = @BillingInvoicingId
+
+		IF (@ModuleId IS NULL)
+		BEGIN
+			SELECT 0 AS IsSuccess, 'Invoice does not exist.' AS Message
+			RETURN
+		END
+
+		IF (@ModuleId <> @SOModuleId)
+		BEGIN
+			SELECT 0 AS IsSuccess, 'Re-Open is only supported for Sales Order invoices.' AS Message
+			RETURN
+		END
+
+		IF (ISNULL(@InvoiceStatus,'') <> 'Invoiced')
+		BEGIN
+			SELECT 0 AS IsSuccess, 'Only a posted (Invoiced) invoice can be Re-Opened.' AS Message
+			RETURN
+		END
+
+		-- Payment guard: block re-open if any payment has been received/applied against this invoice (Standard or Proforma)
+		IF EXISTS (
+			SELECT 1 FROM [dbo].[InvoicePayments] WITH(NOLOCK)
+			WHERE [SOBillingInvoicingId] = @BillingInvoicingId
+			  AND ISNULL([IsActive],0) = 1
+			  AND ISNULL([IsDeleted],0) = 0
+			  AND ISNULL([PaymentAmount],0) > 0
+		)
+		BEGIN
+			SELECT 0 AS IsSuccess, 'This invoice cannot be Re-Opened because a payment has been received against it. Please resolve the payment before re-opening the invoice.' AS Message
+			RETURN
+		END
+
+		DECLARE @ReviewedStatusId INT, @ReviewedStatus VARCHAR(50) = 'Reviewed'
+		SELECT @ReviewedStatusId = [InvoiceStatusId] FROM [dbo].[InvoiceStatus] WITH(NOLOCK) WHERE [Status] = @ReviewedStatus
+
+		UPDATE [dbo].[BillingInvoicing]
+		SET		[UpdatedDate] = GETUTCDATE(),
+				[InvoiceStatusId] = @ReviewedStatusId,
+				[InvoiceStatus] = @ReviewedStatus,
+				[IsInvoicePosted] = 0,
+				[PostedDate] = NULL,
+				[UpdatedBy] = @UpdatedBy
+		WHERE	[BillingInvoicingId] = @BillingInvoicingId
+
+		-- When re-opening a Standard invoice, clear the "Standard invoice posted" flag on sibling Proforma invoice(s)
+		IF (@IsPerformaInvoice = 0)
+		BEGIN
+			UPDATE [dbo].[BillingInvoicing]
+			SET		[IsStandardInvoicePosted] = 0
+			WHERE	[ReferenceId] = @ReferenceId
+			AND		[ModuleId] = @ModuleId
+			AND		[IsPerformaInvoice] = 1
+		END
+
+		-- Accounting reversal: only when the company uses PAS accounting (IsAccountByPass = 0).
+		-- If the company does not use PAS accounting (IsAccountByPass = 1), there is no PAS GL entry to reverse.
+		DECLARE @IsAccountByPass BIT = 0
+		SELECT @IsAccountByPass = ISNULL([IsAccountByPass],0) FROM [dbo].[MasterCompany] WITH(NOLOCK) WHERE [MasterCompanyId] = @MasterCompanyId
+
+		IF (ISNULL(@IsAccountByPass,0) = 0)
+		BEGIN
+			EXEC [dbo].[USP_ReverseSOInvoiceAccountingEntry] @BillingInvoicingId = @BillingInvoicingId, @MasterCompanyId = @MasterCompanyId, @UpdatedBy = @UpdatedBy
+		END
+
+		-- Sales Order status update: if the Sales Order was Closed, revert it back to Open
+		DECLARE @ClosedStatusId INT, @OpenStatusId INT
+		SELECT @ClosedStatusId = [Id] FROM [dbo].[MasterSalesOrderStatus] WITH(NOLOCK) WHERE [Name] = 'Closed'
+		SELECT @OpenStatusId = [Id] FROM [dbo].[MasterSalesOrderStatus] WITH(NOLOCK) WHERE [Name] = 'Open'
+
+		IF EXISTS (SELECT 1 FROM [dbo].[SalesOrder] WITH(NOLOCK) WHERE [SalesOrderId] = @ReferenceId AND [StatusId] = @ClosedStatusId)
+		BEGIN
+			UPDATE [dbo].[SalesOrder]
+			SET		[StatusId] = @OpenStatusId,
+					[StatusChangeDate] = GETUTCDATE(),
+					[UpdatedDate] = GETUTCDATE(),
+					[UpdatedBy] = @UpdatedBy
+			WHERE	[SalesOrderId] = @ReferenceId
+		END
+
+		SELECT 1 AS IsSuccess, 'Invoice Re-Opened successfully.' AS Message
+
+	END
+	END TRY
+	BEGIN CATCH
+		DECLARE @ErrorLogID INT, @DatabaseName VARCHAR(100) = db_name()
+-----------------------------------PLEASE CHANGE THE VALUES FROM HERE TILL THE NEXT LINE----------------------------------------
+		, @AdhocComments     VARCHAR(150)    = 'USP_ReOpenSalesOrderInvoice'
+		, @ProcedureParameters VARCHAR(3000)  = '@Parameter1 = ''' + ISNULL(CONVERT(VARCHAR(30),@BillingInvoicingId), '') + '@Parameter2= ''' + ISNULL(@UpdatedBy, '') + ''
+		, @ApplicationName VARCHAR(100) = 'PAS'
+-----------------------------------PLEASE DO NOT EDIT BELOW----------------------------------------
+		exec spLogException
+			@DatabaseName           = @DatabaseName
+			, @AdhocComments          = @AdhocComments
+			, @ProcedureParameters = @ProcedureParameters
+			, @ApplicationName        =  @ApplicationName
+			, @ErrorLogID                    = @ErrorLogID OUTPUT ;
+		RAISERROR ('Unexpected Error Occured in the database. Please let the support team know of the error number : %d', 16, 1,@ErrorLogID)
+		RETURN(1);
+	END CATCH
+END


### PR DESCRIPTION
Added USP_ReOpenSalesOrderInvoice: blocks re-open if a payment exists, resets the invoice to Reviewed, and reverts the Sales Order status back to Open.
Added USP_ReverseSOInvoiceAccountingEntry: reverses the exact Debit/Credit GL entries posted at invoicing time (PAS accounting only) and flags them as reversed.
