### PR TITLE
PN-17439

### DIFF
--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetCommonBillingInvoiceChildListNew.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetCommonBillingInvoiceChildListNew.sql
@@ -29,6 +29,8 @@
 	16   31/July/2026 Moin Bloch		[PN-17513] - Added UNION ALL arm in SO @AllowBillingBeforeShipping=0 branch to include Service/Non-Stock parts even when no shipment has been done, since these items are never physically shipped.
 	17   03/Aug/2026  Moin Bloch		[PN-17540] - Fix For Duplicate Issue
 	18   11-Aug-2026  Rajesh Gami		[PN-17636] Added IsReOpen Flag to handle the Reopen Invoice
+	19   05/Aug/2026  Kishor Makwana	[PN-17439] - Modify SO & SOQ Part Grid logic to allow duplicate PN + Condition rows (uniqueness by PN + Condition + SalesOrderPartId, displayed via Sequence Number)
+	
 **************************************************************/
 --   EXEC [dbo].[GetCommonBillingInvoiceChildListNew] 11268,11723,1,10,2,10,103606
 
@@ -565,24 +567,24 @@ BEGIN
 					sosi.SalesOrderShippingId,   
 					sosi.SalesOrderShippingItemId,   
 					CASE WHEN sop.SalesOrderPartId IS NOT NULL and  (SELECT COUNT(1) FROM DBO.BillingInvoicingItems sobii_1 WITH(NOLOCK) 
-					WHERE sobii_1.BillingInvoicingId = sobi.BillingInvoicingId and sobii_1.ItemMasterId = sop.ItemMasterId
-					AND ISNULL(sobii_1.IsPerformaInvoice, 0) = 0) > 0 THEN sobii.BillingInvoicingId  
+					WHERE sobii_1.BillingInvoicingId = sobi.BillingInvoicingId and sobii_1.ItemMasterId = sop.ItemMasterId and sobii_1.SubReferenceId= sop.SalesOrderPartId
+					AND ISNULL(sobii_1.IsPerformaInvoice, 0) = 0 AND sobii_1.SubReferenceId = @SubReferenceId) > 0 THEN sobii.BillingInvoicingId  
 					ELSE NULL END AS BillingInvoicingId,
 
 					(SELECT TOP 1 case when CAST(a.InvoiceDate as date) = CAST('0001-01-01 00:00:00' as date)then null else (Cast(DBO.ConvertUTCtoLocal(a.InvoiceDate, @CurrntEmpTimeZoneDesc) as Date))end FROM dbo.BillingInvoicing a WITH (NOLOCK)
-						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
-						Where a.ReferenceId = @ReferenceId AND b.ItemMasterId = sop.ItemMasterId 
+						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId  and b.SubReferenceId= sop.SalesOrderPartId
+						Where a.ReferenceId = @ReferenceId AND b.ItemMasterId = sop.ItemMasterId AND b.SubReferenceId = @SubReferenceId
 						AND stk.StockLineId = b.StockLineId AND ShippingId = sosi.SalesOrderShippingId
 						AND ISNULL(a.IsPerformaInvoice,0) = 0 AND b.ModuleId = @SOModuleId AND ISNULL(b.IsPerformaInvoice,0) = 0) AS InvoiceDate,
 					CASE WHEN sop.SalesOrderPartId IS NOT NULL and  (SELECT COUNT(1) FROM DBO.BillingInvoicingItems sobii_1 WITH(NOLOCK) 
-					WHERE sobii_1.BillingInvoicingId = sobi.BillingInvoicingId and sobii_1.ItemMasterId = sop.ItemMasterId 
+					WHERE sobii_1.BillingInvoicingId = sobi.BillingInvoicingId and sobii_1.ItemMasterId = sop.ItemMasterId  AND sobii_1.SubReferenceId = @SubReferenceId
 					AND ISNULL(sobii_1.IsPerformaInvoice, 0) = 0) >0  THEN sobi.InvoiceNo ELSE NULL END AS InvoiceNo,
 					--sobi.InvoiceTypeId,
 					(CASE WHEN  @DefaultInvoiceTypeId > 0 THEN @DefaultInvoiceTypeId ELSE sobi.InvoiceTypeId END) As InvoiceTypeId,
 					sos.SOShippingNum, 
 					sosi.QtyShipped as QtyToBill,   
 					so.SalesOrderNumber, 
-					imt.partnumber, 
+					CAST(sop.SequenceNumber as VARCHAR(10))+' - '+imt.partnumber, 
 					imt.ItemMasterId,
 					sop.ConditionId,
 					imt.PartDescription, 
@@ -591,18 +593,18 @@ BEGIN
 					cr.[Name] as CustomerName,   
 					stk.StockLineId,  
 					(SELECT TOP 1 b.QtyBilled FROM dbo.BillingInvoicing a WITH (NOLOCK) 
-						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
-						WHERE a.ReferenceId = @ReferenceId AND b.ItemMasterId = sop.ItemMasterId  AND b.ModuleId = @SOModuleId
+						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId and b.SubReferenceId= sop.SalesOrderPartId
+						WHERE a.ReferenceId = @ReferenceId AND b.ItemMasterId = sop.ItemMasterId  AND b.ModuleId = @SOModuleId AND SubReferenceId = @SubReferenceId
 						AND stk.StockLineId = b.StockLineId AND b.ShippingId = sosi.SalesOrderShippingId
 						AND ISNULL(a.IsPerformaInvoice,0) = 0 AND ISNULL(b.IsPerformaInvoice,0) = 0) AS QtyBilled,  
 					--sobii.QtyBilled,
-					0 AS ItemNo,  
-					sop.SalesOrderId, 
-					sop.SalesOrderPartId, 
+					sop.SequenceNumber AS ItemNo,
+					sop.SalesOrderId,
+					sop.SalesOrderPartId,
 					stk.SalesOrderStocklineId,
-					cond.Description as 'Condition',   
+					cond.Description as 'Condition',
 					CASE WHEN currb.Code IS NOT NULL THEN currb.Code ELSE curr.Code END AS 'CurrencyCode',
-					CASE WHEN ISNULL(sobii.BillingInvoicingId, 0) > 0 THEN ISNULL(sobi.GrandTotal, 0) ELSE 
+					CASE WHEN ISNULL(sobii.BillingInvoicingId, 0) > 0 THEN ISNULL(sobi.GrandTotal, 0) ELSE
 					((ISNULL(SOSC.NetSaleAmount, 0) / ISNULL(STK.QtyOrder, 1)) * sosi.QtyShipped)
 					END 
 					as 'TotalSales',  
@@ -629,9 +631,9 @@ BEGIN
 					WHERE [SO].[SalesOrderId] = @ReferenceId AND so.ChargesBilingMethodId = @FlateBilingMethodId)
 					AS TotalFlatCharges,
 					(SELECT TOP 1 a.InvoiceStatus FROM dbo.BillingInvoicing a WITH (NOLOCK) 
-						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
+						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId and b.SubReferenceId= sop.SalesOrderPartId
 						Where a.ReferenceId = @ReferenceId AND sobii.BillingInvoicingId = a.BillingInvoicingId AND b.ItemMasterId = sop.ItemMasterId 
-						AND stk.StockLineId = b.StockLineId AND ShippingId = sosi.SalesOrderShippingId
+						AND stk.StockLineId = b.StockLineId AND ShippingId = sosi.SalesOrderShippingId AND b.SubReferenceId = @SubReferenceId
 						AND ISNULL(a.IsPerformaInvoice,0) = 0 AND ISNULL(b.IsPerformaInvoice,0) = 0  AND a.ModuleId = @SOModuleId ORDER BY a.InvoiceDate DESC) AS InvoiceStatus,
 					--sobi.InvoiceStatus,
 					sos.SmentNum AS 'SmentNo',
@@ -658,8 +660,8 @@ BEGIN
 					LEFT JOIN DBO.SalesOrderStocklineV1 stk WITH (NOLOCK) ON stk.SalesOrderPartId = sop.SalesOrderPartId
 					LEFT JOIN DBO.SalesOrderStocklineCost sosc WITH (NOLOCK) ON sosc.SalesOrderStocklineId = stk.SalesOrderStocklineId
 					INNER JOIN DBO.SOPickTicket SOPT WITH (NOLOCK) on SOPT.SalesOrderId = sos.SalesOrderId AND SOPT.SalesOrderPartStocklineId = stk.SalesOrderStocklineId
-					INNER JOIN DBO.SalesOrderShippingItem sosi WITH (NOLOCK) on sosi.SalesOrderShippingId = sos.SalesOrderShippingId  AND sosi.SOPickTicketId = SOPT.SOPickTicketId
-					LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.SubReferenceId = sop.SalesOrderPartId AND sobii.ItemMasterId = sop.ItemMasterId AND ISNULL(sobii.IsPerformaInvoice,0) = 0  AND SOBII.ModuleId = @SOModuleId
+					INNER JOIN DBO.SalesOrderShippingItem sosi WITH (NOLOCK) on sosi.SalesOrderShippingId = sos.SalesOrderShippingId  AND sosi.SOPickTicketId = SOPT.SOPickTicketId AND sosi.SalesOrderPartId=sop.SalesOrderPartId AND sosi.SalesOrderPartId=@SubReferenceId
+					LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.SubReferenceId = sop.SalesOrderPartId AND sobii.ItemMasterId = sop.ItemMasterId and sobii.SubReferenceId = @SubReferenceId AND ISNULL(sobii.IsPerformaInvoice,0) = 0  AND SOBII.ModuleId = @SOModuleId
 					LEFT JOIN DBO.BillingInvoicing sobi WITH (NOLOCK) on sobi.BillingInvoicingId = sobii.BillingInvoicingId AND ISNULL(sobi.IsPerformaInvoice,0) = 0  AND SOBI.ModuleId = @SOModuleId
 					INNER JOIN DBO.SalesOrder so WITH (NOLOCK) on so.SalesOrderId = sop.SalesOrderId  
 					LEFT JOIN DBO.ItemMaster imt WITH (NOLOCK) on imt.ItemMasterId = sop.ItemMasterId  
@@ -669,12 +671,12 @@ BEGIN
 					LEFT JOIN DBO.Condition cond WITH (NOLOCK) on cond.ConditionId = sop.ConditionId  
 					LEFT JOIN DBO.Currency curr WITH (NOLOCK) on curr.CurrencyId = so.FunctionalCurrencyId 
 					LEFT JOIN DBO.Currency currb WITH (NOLOCK) on currb.CurrencyId = sobi.CurrencyId
-					WHERE sos.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId  
-					GROUP BY sosi.SalesOrderShippingId, sosi.SalesOrderShippingItemId, sos.SOShippingNum, so.SalesOrderNumber, imt.ItemMasterId, imt.partnumber,imt.ItemMasterId,sop.ConditionId, imt.PartDescription, sl.StockLineNumber,  
+					WHERE sos.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId AND sop.SalesOrderPartId = @SubReferenceId
+					GROUP BY sosi.SalesOrderShippingId, sosi.SalesOrderShippingItemId, sos.SOShippingNum, so.SalesOrderNumber, imt.ItemMasterId, imt.partnumber,imt.ItemMasterId,sop.ConditionId, imt.PartDescription, sl.StockLineNumber,
 					sl.SerialNumber, sobii.SerialNumber, cr.[Name], sop.SalesOrderId, sop.SalesOrderPartId, stk.SalesOrderStocklineId, cond.Description, curr.Code, currb.Code, stk.StockLineId,  
 					sobi.InvoiceStatus, sosi.QtyShipped, sop.ItemMasterId, sobi.InvoiceStatus,SOSC.NetSaleAmount, sobi.InvoiceNo, sobi.InvoiceTypeId,
 					SOPC.TaxAmount, SOPC.TaxPercentage, sos.SmentNum, sobii.VersionNo,sobi.IsVersionIncrease,sobii.IsVersionIncrease, sobi.BillingInvoicingId, sobii.BillingInvoicingId,sobi.GrandTotal,sobi.[IsInvoicePosted],
-					sop.ECCN ,sop.HSCODE ,sop.[Weight] ,sop.SizeLength ,sop.SizeWidth ,sop.SizeHeight, stk.QtyOrder,imt.isSerialized,sobi.CreditMemoHeaderId,sobi.[IsReOpened]
+					sop.ECCN ,sop.HSCODE ,sop.[Weight] ,sop.SizeLength ,sop.SizeWidth ,sop.SizeHeight, stk.QtyOrder,imt.isSerialized,sobi.CreditMemoHeaderId,sobi.[IsReOpened], sop.SequenceNumber
 
 					UNION ALL
 
@@ -689,11 +691,11 @@ BEGIN
 					(CASE WHEN @DefaultInvoiceTypeId > 0 THEN @DefaultInvoiceTypeId ELSE sobi2.InvoiceTypeId END) As InvoiceTypeId,
 					'' AS SOShippingNum,
 					(ISNULL(sop2.QtyOrder,0) - ISNULL((SELECT SUM(ISNULL(b.QtyBilled,0)) FROM dbo.BillingInvoicing a WITH (NOLOCK)
-						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId
-						WHERE a.ReferenceId = @ReferenceId AND a.ModuleId = @SOModuleId AND b.SubReferenceId = sop2.SalesOrderPartId
+						INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
+						WHERE a.ReferenceId = @ReferenceId AND a.ModuleId = @SOModuleId AND b.SubReferenceId = sop2.SalesOrderPartId AND b.SubReferenceId = @SubReferenceId
 						AND ISNULL(a.[IsVersionIncrease],0) = 0  AND  ISNULL(b.[IsVersionIncrease],0) = 0 AND ISNULL(a.IsPerformaInvoice,0) = 0 AND ISNULL(b.IsPerformaInvoice,0) = 0), 0)) AS QtyToBill,
 					so2.SalesOrderNumber,
-					im.partnumber,
+					CAST(sop2.SequenceNumber as VARCHAR(10))+' - '+im.partnumber,
 					im.ItemMasterId,
 					sop2.ConditionId,
 					im.PartDescription,
@@ -702,7 +704,7 @@ BEGIN
 					cr2.[Name] as CustomerName,
 					NULL AS StockLineId,
 					ISNULL(sobii2.QtyBilled,0) AS QtyBilled,
-					0 AS ItemNo,
+					sop2.SequenceNumber AS ItemNo,
 					sop2.SalesOrderId,
 					sop2.SalesOrderPartId,
 					NULL AS SalesOrderStocklineId,
@@ -747,13 +749,13 @@ BEGIN
 					LEFT JOIN DBO.Condition cond2 WITH (NOLOCK) ON cond2.ConditionId = sop2.ConditionId
 					LEFT JOIN DBO.Currency curr2 WITH (NOLOCK) ON curr2.CurrencyId = so2.FunctionalCurrencyId
 					LEFT JOIN DBO.Currency currb2 WITH (NOLOCK) ON currb2.CurrencyId = sobi2.CurrencyId
-					WHERE sop2.SalesOrderId = @ReferenceId AND sop2.ItemMasterId = @ItemMasterId AND sop2.ConditionId = @ConditionId
+					WHERE sop2.SalesOrderId = @ReferenceId AND sop2.ItemMasterId = @ItemMasterId AND sop2.ConditionId = @ConditionId AND sop2.SalesOrderPartId = @SubReferenceId
 					AND NOT EXISTS (
 						SELECT 1 FROM DBO.SalesOrderShipping xsos WITH (NOLOCK)
 						INNER JOIN DBO.SalesOrderShippingItem xsosi WITH (NOLOCK) ON xsos.SalesOrderShippingId = xsosi.SalesOrderShippingId
 						INNER JOIN DBO.SOPickTicket xsopt WITH (NOLOCK) ON xsopt.SOPickTicketId = xsosi.SOPickTicketId
 						INNER JOIN DBO.SalesOrderStocklineV1 xstk WITH (NOLOCK) ON xstk.SalesOrderStocklineId = xsopt.SalesOrderPartStocklineId
-						WHERE xsos.SalesOrderId = @ReferenceId AND xstk.SalesOrderPartId = sop2.SalesOrderPartId
+						WHERE xsos.SalesOrderId = @ReferenceId AND xstk.SalesOrderPartId = sop2.SalesOrderPartId AND xsosi.SalesOrderPartId=@SubReferenceId
 					)
 					)
 
@@ -772,7 +774,7 @@ BEGIN
 				BEGIN
 					IF EXISTS (SELECT TOP 1 1 FROM DBO.SalesOrderShipping SOS WITH (NOLOCK) INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
 						INNER JOIN DBO.SalesOrderPartV1 SOP WITH (NOLOCK) on SOP.SalesOrderId = SOS.SalesOrderId AND SOP.SalesOrderPartId = SOSI.SalesOrderPartId
-						WHERE SOS.SalesOrderId = @ReferenceId AND SOP.ItemMasterId = @ItemMasterId AND SOP.ConditionId = @ConditionId)
+						WHERE SOS.SalesOrderId = @ReferenceId AND SOP.ItemMasterId = @ItemMasterId AND SOP.ConditionId = @ConditionId AND SOP.SalesOrderPartId = @SubReferenceId)
 				
 					BEGIN  
 						PRINT 'Main --Exist '
@@ -788,7 +790,7 @@ BEGIN
 							0 AS IndexColumn,
 							(CASE WHEN sobii.IsVersionIncrease = 1 then sobii.ShippingId 
 							else (SELECT TOP 1 SOS.SalesOrderShippingId FROM DBO.SalesOrderShipping SOS 
-							WITH (NOLOCK) INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
+							WITH (NOLOCK) INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId AND SOSI.SalesOrderPartId =@SubReferenceId
 							INNER JOIN DBO.SOPickTicket SO_PICK WITH (NOLOCK) on SO_PICK.SOPickTicketId = SOSI.SOPickTicketId
 							WHERE SOS.SalesOrderId = @ReferenceId AND SO_PICK.SOPickTicketId = SOPPick.SOPickTicketId) end) AS SalesOrderShippingId,  
 							SOSI.SalesOrderShippingItemId,
@@ -802,7 +804,7 @@ BEGIN
 							else 
 								(SELECT top 1 SOS.SOShippingNum 
 								FROM DBO.SalesOrderShipping SOS WITH (NOLOCK) 
-								INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
+								INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId AND SOSI.SalesOrderPartId =@SubReferenceId
 								INNER JOIN DBO.SOPickTicket SOPICK WITH (NOLOCK) on SOPICK.SOPickTicketId = SOSI.SOPickTicketId
 								INNER JOIN DBO.SalesOrderStocklineV1 SOSB WITH (NOLOCK) on SOSB.SalesOrderStocklineId = SOPICK.SalesOrderPartStocklineId
 								WHERE SOS.SalesOrderId = @ReferenceId AND SOSB.SalesOrderStocklineId = STK.SalesOrderStocklineId
@@ -811,38 +813,38 @@ BEGIN
 				
 							CASE WHEN sobii.IsVersionIncrease = 1 THEN 0 ELSE (SELECT SUM(ISNULL(SOSI.QtyShipped, 0)) 
 							FROM DBO.SalesOrderShipping SOS WITH (NOLOCK) 
-							INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
+							INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId AND SOSI.SalesOrderPartId =@SubReferenceId
 							INNER JOIN DBO.SOPickTicket SOPT WITH (NOLOCK) ON SOPT.SOPickTicketId = SOSI.SOPickTicketId
 							INNER JOIN DBO.SalesOrderStocklineV1 SOPS WITH (NOLOCK) ON SOPS.SalesOrderStocklineId = SOPT.SalesOrderPartStocklineId
 							WHERE SOS.SalesOrderId = @ReferenceId AND stk.SalesOrderStocklineId = SOPS.SalesOrderStocklineId
 							AND SOSI.SOPickTicketId = SOPPick.SOPickTicketId) end  as QtyToBill,
 				
-							so.SalesOrderNumber, imt.partnumber, imt.ItemMasterId, sop.ConditionId, imt.PartDescription, sl.StockLineNumber,  
+							so.SalesOrderNumber, CAST(sop.SequenceNumber as VARCHAR(10))+' - '+imt.partnumber, imt.ItemMasterId, sop.ConditionId, imt.PartDescription, sl.StockLineNumber,  
 							--sl.SerialNumber, 
 							CASE WHEN sobii.SerialNumber IS NOT NULL THEN sobii.SerialNumber ELSE sl.SerialNumber END SerialNumber,
 							cr.[Name] as CustomerName,   
 							stk.StockLineId,  
 							ISNULL((SELECT ISNULL(b.QtyBilled, 0) FROM dbo.BillingInvoicing a WITH (NOLOCK) 
-								INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
+								INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId  AND b.SubReferenceId = sop.SalesOrderPartId
 								WHERE b.BillingInvoicingItemId = SOBII.BillingInvoicingItemId AND b.StockLineId = SOBII.StockLineId
-								AND a.ReferenceId = @ReferenceId AND a.ModuleId = @SOModuleId
+								AND a.ReferenceId = @ReferenceId AND a.ModuleId = @SOModuleId  AND b.SubReferenceId = @SubReferenceId
 								AND ISNULL(a.IsPerformaInvoice,0) = 0 AND ISNULL(b.IsPerformaInvoice,0) = 0), 0) AS QtyBilled,
-							0 AS ItemNo, 
-							sop.SalesOrderId, sop.SalesOrderPartId, stk.SalesOrderStocklineId, cond.Description as 'Condition',   
+							sop.SequenceNumber AS ItemNo,
+							sop.SalesOrderId, sop.SalesOrderPartId, stk.SalesOrderStocklineId, cond.Description as 'Condition',
 							CASE WHEN currb.Code IS NOT NULL THEN currb.Code ELSE curr.Code END AS 'CurrencyCode',
-							CASE WHEN ISNULL(sobi.BillingInvoicingId, 0) = 0 THEN ((ISNULL(SOSC.NetSaleAmount, 0) / ISNULL(STK.QtyOrder, 0)) * ((SELECT SUM(ISNULL(SOSI.QtyShipped, 0)) 
+							CASE WHEN ISNULL(sobi.BillingInvoicingId, 0) = 0 THEN ((ISNULL(SOSC.NetSaleAmount, 0) / ISNULL(STK.QtyOrder, 0)) * ((SELECT SUM(ISNULL(SOSI.QtyShipped, 0))
 							FROM DBO.SalesOrderShipping SOS WITH (NOLOCK) 
-							INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
+							INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId AND SOSI.SalesOrderPartId =@SubReferenceId
 							INNER JOIN DBO.SOPickTicket SOPT WITH (NOLOCK) ON SOPT.SOPickTicketId = SOSI.SOPickTicketId
 							INNER JOIN DBO.SalesOrderStocklineV1 SOPS WITH (NOLOCK) ON SOPS.SalesOrderStocklineId = SOPT.SalesOrderPartStocklineId
-							WHERE SOS.SalesOrderId = @ReferenceId AND stk.SalesOrderStocklineId = SOPS.SalesOrderStocklineId
+							WHERE SOS.SalesOrderId = @ReferenceId AND stk.SalesOrderStocklineId = SOPS.SalesOrderStocklineId 
 							AND SOSI.SOPickTicketId = SOPPick.SOPickTicketId)))
 							ELSE sobii.GrandTotal END as 'TotalSales',  
 
 							((ISNULL(SOSC.NetSaleAmount, 0) / ISNULL(STK.QtyOrder, 0)) * 
 							(ISNULL((SELECT SUM(ISNULL(SOSI.QtyShipped, 0)) 
 							FROM DBO.SalesOrderShipping SOS WITH (NOLOCK) 
-							INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
+							INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId AND SOSI.SalesOrderPartId =@SubReferenceId
 							INNER JOIN DBO.SOPickTicket SOPT WITH (NOLOCK) ON SOPT.SOPickTicketId = SOSI.SOPickTicketId
 							INNER JOIN DBO.SalesOrderPartV1 SOPI WITH (NOLOCK) on SOPI.SalesOrderId = SOS.SalesOrderId AND SOPI.SalesOrderPartId = SOSI.SalesOrderPartId
 							WHERE SOS.SalesOrderId = @ReferenceId AND SOPT.SalesOrderPartStocklineId = stk.SalesOrderStocklineId
@@ -873,11 +875,11 @@ BEGIN
 							AS TotalFlatCharges,
 
 							(SELECT a.InvoiceStatus FROM dbo.BillingInvoicing a WITH (NOLOCK) 
-								INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
-								Where a.ReferenceId = @ReferenceId AND b.BillingInvoicingItemId = sobii.BillingInvoicingItemId  AND a.ModuleId = @SOModuleId
+								INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId  AND b.SubReferenceId = sop.SalesOrderPartId
+								Where a.ReferenceId = @ReferenceId AND b.BillingInvoicingItemId = sobii.BillingInvoicingItemId  AND a.ModuleId = @SOModuleId AND b.SubReferenceId = @SubReferenceId
 								AND ISNULL(a.IsPerformaInvoice,0) = 0 AND ISNULL(b.IsPerformaInvoice,0) = 0) AS InvoiceStatus,
 							(CASE WHEN sobii.IsVersionIncrease = 1 then (CASE WHEN SOBII.ShippingId > 0 THEN 1 ELSE 0 END) else 1 end) AS 'SmentNo',
-							sobii.VersionNo,
+							sobii.VersionNo, 
 							(CASE WHEN sobi.IsVersionIncrease = 1 then 0 else 1 end) IsVersionIncrease,
 							CASE WHEN sobi.BillingInvoicingId IS NULL THEN 1 ELSE 0 END AS IsNewInvoice,
 							0 AS IsProformaInvoice,
@@ -899,8 +901,8 @@ BEGIN
 							LEFT JOIN DBO.SalesOrderStocklineV1 stk WITH (NOLOCK) ON stk.SalesOrderPartId = sop.SalesOrderPartId AND sop.SalesOrderId = @ReferenceId
 							LEFT JOIN DBO.SalesOrderStockLineCost SOSC WITH (NOLOCK) ON SOSC.SalesOrderStocklineId = stk.SalesOrderStocklineId
 							LEFT JOIN DBO.SOPickTicket SOPPick WITH (NOLOCK) on SOPPick.SalesOrderId = sop.SalesOrderId AND SOPPick.SalesOrderPartId = sop.SalesOrderPartId AND SOPPick.SalesOrderPartStocklineId = stk.SalesOrderStocklineId
-							LEFT JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) on SOSI.SOPickTicketId = SOPPick.SOPickTicketId
-							LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.ShippingId = SOSI.SalesOrderShippingId AND sobii.StockLineId = stk.StockLineId AND ISNULL(sobii.IsPerformaInvoice,0) = 0  AND SOBII.ModuleId = @SOModuleId
+							LEFT JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) on SOSI.SOPickTicketId = SOPPick.SOPickTicketId AND SOSI.SalesOrderPartId =@SubReferenceId
+							LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.ShippingId = SOSI.SalesOrderShippingId AND sobii.StockLineId = stk.StockLineId AND sobii.SubReferenceId = sop.SalesOrderPartId AND ISNULL(sobii.IsPerformaInvoice,0) = 0  AND SOBII.ModuleId = @SOModuleId
 							LEFT JOIN DBO.BillingInvoicing sobi WITH (NOLOCK) on sobi.BillingInvoicingId = sobii.BillingInvoicingId  AND ISNULL(sobi.IsPerformaInvoice,0) = 0 AND sobi.ReferenceId = @ReferenceId AND SOBI.ModuleId = @SOModuleId
 							LEFT JOIN DBO.ItemMaster imt WITH (NOLOCK) on imt.ItemMasterId = sop.ItemMasterId  
 							LEFT JOIN DBO.Stockline sl WITH (NOLOCK) on sl.StockLineId = stk.StockLineId  
@@ -909,7 +911,7 @@ BEGIN
 							LEFT JOIN DBO.Currency curr WITH (NOLOCK) on curr.CurrencyId = imt.PurchaseCurrencyId  
 							LEFT JOIN DBO.Currency currb WITH (NOLOCK) on currb.CurrencyId = sobi.CurrencyId
 							LEFT JOIN DBO.SalesOrderReserveParts SOR WITH (NOLOCK) on SOR.SalesOrderPartId = sop.SalesOrderPartId AND SOR.StockLineId = Stk.StockLineId AND SOR.SalesOrderId = @ReferenceId
-							WHERE sop.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId
+							WHERE sop.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId AND sop.SalesOrderPartId = @SubReferenceId
 							AND (SOSI.SalesOrderShippingItemId IS NOT NULL))
 
 							UNION ALL
@@ -925,7 +927,7 @@ BEGIN
 								'' AS SOShippingNum,
 								ISNULL(SOR.QtyToReserve, 0) AS QtyToBill,
 								so.SalesOrderNumber,
-								imt.partnumber, 
+								CAST(sop.SequenceNumber as VARCHAR(10))+' - '+imt.partnumber, 
 								imt.ItemMasterId,
 								sop.ConditionId, 
 								imt.PartDescription, 
@@ -934,8 +936,8 @@ BEGIN
 								cr.[Name] as CustomerName,   
 								stk.StockLineId,
 								ISNULL(sobii.QtyBilled, 0) AS QtyBilled,
-								0 AS ItemNo,  
-								sop.SalesOrderId, 
+								sop.SequenceNumber AS ItemNo,
+								sop.SalesOrderId,
 								sop.SalesOrderPartId, 
 								stk.SalesOrderStocklineId,
 								cond.Description as 'Condition',   
@@ -943,10 +945,10 @@ BEGIN
 								((ISNULL(SOSC.NetSaleAmount, 0) / STK.QtyOrder) * SOR.QtyToReserve) AS 'TotalSales',
 								((ISNULL(SOSC.NetSaleAmount, 0) / ISNULL(STK.QtyOrder, 0)) * (ISNULL((SELECT SUM(ISNULL(SOSI.QtyShipped, 0)) 
 								FROM DBO.SalesOrderShipping SOS WITH (NOLOCK) 
-								INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId
+								INNER JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) ON SOS.SalesOrderShippingId = SOSI.SalesOrderShippingId AND SOSI.SalesOrderPartId =@SubReferenceId
 								INNER JOIN DBO.SOPickTicket SOPT WITH (NOLOCK) ON SOPT.SOPickTicketId = SOSI.SOPickTicketId
 								INNER JOIN DBO.SalesOrderPartV1 SOPI WITH (NOLOCK) on SOPI.SalesOrderId = SOS.SalesOrderId AND SOPI.SalesOrderPartId = SOSI.SalesOrderPartId
-								WHERE SOS.SalesOrderId = @ReferenceId AND SOPT.SalesOrderPartStocklineId = stk.SalesOrderStocklineId
+								WHERE SOS.SalesOrderId = @ReferenceId AND SOPT.SalesOrderPartStocklineId = stk.SalesOrderStocklineId  AND SOPI.SalesOrderPartId = @SubReferenceId
 								), 0) + ISNULL(SOR.QtyToReserve, 0))) AS TotalUnitCost,
 								0 AS TotalFreight,
 								0 AS TotalFlatFreight,
@@ -976,9 +978,9 @@ BEGIN
 								LEFT JOIN DBO.SalesOrderStocklineV1 stk WITH (NOLOCK) ON stk.SalesOrderPartId = sop.SalesOrderPartId
 								LEFT JOIN DBO.SalesOrderReserveParts SOR WITH (NOLOCK) on SOR.SalesOrderPartId = sop.SalesOrderPartId AND SOR.StockLineId = Stk.StockLineId AND SOR.SalesOrderId = @ReferenceId
 								LEFT JOIN DBO.SOPickTicket SOPPick WITH (NOLOCK) on SOPPick.SalesOrderId = sop.SalesOrderId AND SOPPick.SalesOrderPartStocklineId = stk.SalesOrderStocklineId
-								LEFT JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) on SOSI.SOPickTicketId = SOPPick.SOPickTicketId
+								LEFT JOIN DBO.SalesOrderShippingItem SOSI WITH (NOLOCK) on SOSI.SOPickTicketId = SOPPick.SOPickTicketId AND SOSI.SalesOrderPartId =@SubReferenceId
 								LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.SubReferenceId = sop.SalesOrderPartId AND sobii.StockLineId = stk.StockLineId AND ISNULL(sobii.IsPerformaInvoice,0) = 0  AND SOBII.ModuleId = @SOModuleId
-								LEFT JOIN DBO.BillingInvoicing sobi WITH (NOLOCK) on sobi.BillingInvoicingId = sobii.BillingInvoicingId AND ISNULL(sobi.IsPerformaInvoice,0) = 0 AND sobi.ReferenceId = @ReferenceId  AND SOBI.ModuleId = @SOModuleId
+								LEFT JOIN DBO.BillingInvoicing sobi WITH (NOLOCK) on sobi.BillingInvoicingId = sobii.BillingInvoicingId AND ISNULL(sobi.IsPerformaInvoice,0) = 0 AND sobi.ReferenceId = @ReferenceId AND sobii.SubReferenceId =@SubReferenceId  AND SOBI.ModuleId = @SOModuleId
 								LEFT JOIN DBO.ItemMaster imt WITH (NOLOCK) on imt.ItemMasterId = sop.ItemMasterId  
 								LEFT JOIN DBO.Stockline sl WITH (NOLOCK) on sl.StockLineId = stk.StockLineId  
 								LEFT JOIN DBO.Customer cr WITH (NOLOCK) on cr.CustomerId = so.CustomerId  
@@ -987,7 +989,7 @@ BEGIN
 								LEFT JOIN DBO.Currency currb WITH (NOLOCK) on currb.CurrencyId = sobi.CurrencyId
 								LEFT JOIN SalesOrderApproval soapr WITH(NOLOCK) on soapr.SalesOrderId = @ReferenceId and soapr.SalesOrderPartId = sop.SalesOrderPartId AND soapr.CustomerStatusId = 2
 								LEFT JOIN DBO.SalesOrderStockLineCost SOSC WITH (NOLOCK) ON SOSC.SalesOrderStocklineId = stk.SalesOrderStocklineId
-							WHERE SOP.SalesOrderId = @ReferenceId AND SOP.ItemMasterId = @ItemMasterId and SOP.ConditionId = @ConditionId
+							WHERE SOP.SalesOrderId = @ReferenceId AND SOP.ItemMasterId = @ItemMasterId and SOP.ConditionId = @ConditionId AND SOP.SalesOrderPartId = @SubReferenceId
 							AND (SOSI.SalesOrderShippingItemId IS NULL AND ISNULL(SOR.QtyToReserve, 0) > 0)
 							ORDER BY IsProformaInvoice ASC
 
@@ -1142,7 +1144,7 @@ BEGIN
 							(CASE WHEN  @DefaultInvoiceTypeId > 0 THEN @DefaultInvoiceTypeId ELSE sobi.InvoiceTypeId END) As InvoiceTypeId,
 							'' AS SOShippingNum,
 							so.SalesOrderNumber, 
-							imt.partnumber, 
+							CAST(sop.SequenceNumber as VARCHAR(10))+' - '+imt.partnumber, 
 							imt.ItemMasterId,
 							sop.ConditionId, 
 							imt.PartDescription, 
@@ -1151,8 +1153,8 @@ BEGIN
 							CASE WHEN sobii.SerialNumber IS NOT NULL THEN sobii.SerialNumber ELSE sl.SerialNumber END AS SerialNumber,
 							cr.[Name] as CustomerName,   
 							ISNULL(stk.StockLineId, 0) StockLineId,
-							0 AS ItemNo,  
-							sop.SalesOrderId, 
+							sop.SequenceNumber AS ItemNo,
+							sop.SalesOrderId,
 							sop.SalesOrderPartId, 
 							stk.SalesOrderStocklineId,
 							cond.Description as 'Condition',   
@@ -1180,7 +1182,7 @@ BEGIN
 							LEFT JOIN DBO.SalesOrderStocklineV1 stk WITH (NOLOCK) ON stk.SalesOrderPartId = sop.SalesOrderPartId
 							INNER JOIN DBO.SalesOrder so WITH (NOLOCK) on so.SalesOrderId = sop.SalesOrderId 
 							INNER JOIN DBO.SalesOrderReserveParts SOR WITH (NOLOCK) on SOR.SalesOrderPartId = sop.SalesOrderPartId AND SOR.StockLineId = Stk.StockLineId AND SOR.SalesOrderId = @ReferenceId
-							LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.SubReferenceId = sop.SalesOrderPartId AND sobii.StockLineId = stk.StockLineId AND ISNULL(sobii.IsPerformaInvoice,0) = 0 AND SOBII.ModuleId = @SOModuleId
+							LEFT JOIN DBO.BillingInvoicingItems sobii WITH (NOLOCK) on sobii.SubReferenceId = sop.SalesOrderPartId AND sobii.StockLineId = stk.StockLineId AND ISNULL(sobii.IsPerformaInvoice,0) = 0 AND SOBII.ModuleId = @SOModuleId AND sobii.SubReferenceId =@SubReferenceId
 							LEFT JOIN DBO.BillingInvoicing sobi WITH (NOLOCK) on sobi.BillingInvoicingId = sobii.BillingInvoicingId AND ISNULL(sobi.IsPerformaInvoice,0) = 0 AND sobi.ReferenceId = @ReferenceId AND SOBI.ModuleId = @SOModuleId
 							LEFT JOIN DBO.ItemMaster imt WITH (NOLOCK) on imt.ItemMasterId = sop.ItemMasterId  
 							LEFT JOIN DBO.Stockline sl WITH (NOLOCK) on sl.StockLineId = stk.StockLineId  
@@ -1191,7 +1193,7 @@ BEGIN
 							LEFT JOIN SalesOrderApproval soapr WITH(NOLOCK) on soapr.SalesOrderId = @ReferenceId and soapr.SalesOrderPartId = sop.SalesOrderPartId AND soapr.CustomerStatusId = 2
 							INNER JOIN DBO.SalesOrderPartCost SOPC WITH (NOLOCK) ON SOPC.SalesOrderPartId = sop.SalesOrderPartId
 							LEFT JOIN DBO.SalesOrderStockLineCost SOSC WITH (NOLOCK) ON SOSC.SalesOrderStocklineId = stk.SalesOrderStocklineId
-						WHERE SOP.SalesOrderId = @ReferenceId AND SOP.ItemMasterId = @ItemMasterId and SOP.ConditionId = @ConditionId
+						WHERE SOP.SalesOrderId = @ReferenceId AND SOP.ItemMasterId = @ItemMasterId and SOP.ConditionId = @ConditionId AND SOP.SalesOrderPartId = @SubReferenceId
 						AND SOR.QtyToReserve > 0
 
 						UPDATE  #InvoiceMainDetails SET QtyToBill = tmpcash.QtyToBill
@@ -1323,7 +1325,7 @@ BEGIN
 						sobi.InvoiceTypeId,
 						'' AS SOShippingNum, 
 						ISNULL(stk.QtyOrder, 0) AS QtyToBill, 
-						so.SalesOrderNumber, imt.partnumber, imt.ItemMasterId, sop.ConditionId, imt.PartDescription, sl.StockLineNumber,  
+						so.SalesOrderNumber, CAST(sop.SequenceNumber as VARCHAR(10))+' - '+imt.partnumber, imt.ItemMasterId, sop.ConditionId, imt.PartDescription, sl.StockLineNumber,  
 						--sl.SerialNumber, 
 						CASE WHEN sobii.SerialNumber IS NOT NULL THEN sobii.SerialNumber ELSE sl.SerialNumber END AS SerialNumber,
 						cr.[Name] AS CustomerName,   
@@ -1331,9 +1333,9 @@ BEGIN
 						ISNULL((SELECT ISNULL(b.QtyBilled, 0)
 							FROM dbo.BillingInvoicing a WITH (NOLOCK) 
 							INNER JOIN dbo.BillingInvoicingItems b WITH (NOLOCK) ON a.BillingInvoicingId = b.BillingInvoicingId 
-							WHERE b.BillingInvoicingItemId = SOBII.BillingInvoicingItemId  AND a.ModuleId = @SOModuleId AND ISNULL(b.IsPerformaInvoice,0) = 1 AND ISNULL(a.IsPerformaInvoice,0) = 1), 0) AS QtyBilled,  
-						0 AS ItemNo,  
-						sop.SalesOrderId, sop.SalesOrderPartId, stk.SalesOrderStocklineId, cond.Description AS 'Condition',   
+							WHERE b.BillingInvoicingItemId = SOBII.BillingInvoicingItemId  AND a.ModuleId = @SOModuleId AND ISNULL(b.IsPerformaInvoice,0) = 1 AND ISNULL(a.IsPerformaInvoice,0) = 1), 0) AS QtyBilled,
+						sop.SequenceNumber AS ItemNo,
+						sop.SalesOrderId, sop.SalesOrderPartId, stk.SalesOrderStocklineId, cond.Description AS 'Condition',
 						CASE WHEN currb.Code IS NOT NULL THEN currb.Code ELSE curr.Code END AS 'CurrencyCode',
 						ISNULL(sobii.GrandTotal, 0) as 'TotalSales',  
 						(SELECT a.InvoiceStatus FROM DBO.BillingInvoicing a WITH (NOLOCK) 
@@ -1391,12 +1393,14 @@ BEGIN
 						LEFT JOIN DBO.Condition cond WITH (NOLOCK) ON cond.ConditionId = sop.ConditionId  
 						LEFT JOIN DBO.Currency curr WITH (NOLOCK) ON curr.CurrencyId = so.FunctionalCurrencyId 
 						LEFT JOIN DBO.Currency currb WITH (NOLOCK) on currb.CurrencyId = sobi.CurrencyId
-						WHERE sop.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId
+						WHERE sop.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId AND sop.SalesOrderPartId = @SubReferenceId
 						)
 
 				;WITH FinalCTE AS(
 					SELECT DISTINCT
 						   ROW_NUMBER() OVER (PARTITION BY SalesOrderPartId, IsProformaInvoice ORDER BY SalesOrderPartId, IsVersionIncrease DESC) AS IndexColumn,
+						   ROW_NUMBER() OVER (PARTITION BY SalesOrderPartId, IsProformaInvoice, ISNULL(BillingInvoicingId,-1), ISNULL(StockLineId,-1), ISNULL(SalesOrderShippingItemId,-1) ORDER BY IsVersionIncrease DESC, QtyBilled DESC, TotalSales DESC) AS DupRank,
+						   ROW_NUMBER() OVER (PARTITION BY SalesOrderPartId, IsProformaInvoice, StockLineId, SalesOrderShippingId, SalesOrderShippingItemId ORDER BY ISNULL(BillingInvoicingId,-1) DESC, IsVersionIncrease DESC, QtyBilled DESC, TotalSales DESC) AS StockLineRank,
 						   SalesOrderShippingId,
 						   SalesOrderShippingItemId,
 						   BillingInvoicingId,
@@ -1545,14 +1549,17 @@ BEGIN
 							SizeHeight,
 							IsVersionIncrease,
 							1,IsSerialized,CreditMemoHeaderId
-						FROM FinalCTE ORDER BY partnumber, IsProformaInvoice DESC ,VersionNo DESC;
+						FROM FinalCTE
+						WHERE DupRank = 1 
+						AND (StockLineId IS NULL OR StockLineRank = 1) 
+						ORDER BY partnumber, IsProformaInvoice DESC ,VersionNo DESC;
 						--ORDER BY partnumber, IsProformaInvoice DESC, InvoiceNo DESC, VersionNo DESC;
 
 						DELETE FROM #InvoiceMainDetails WHERE ISNULL(IsLastInserted,0) = 0
 					
 			END /*********END: SALES ORDER ********/
 			UPDATE #InvoiceMainDetails SET IsFinishGood = (CASE WHEN @IsTearDownWO =  1 THEN 1 ELSE IsFinishGood END)
-			SELECT * FROM #InvoiceMainDetails ORDER BY IsProformaInvoice ASC, BillingInvoicingId DESC,InvoiceNo DESC, VersionNo DESC;	
+			SELECT  * FROM #InvoiceMainDetails ORDER BY IsProformaInvoice ASC, BillingInvoicingId DESC,InvoiceNo DESC, VersionNo DESC;	
 		END TRY    
 		BEGIN CATCH      
 			IF @@trancount > 0

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetCommonBillingInvoiceListNew.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetCommonBillingInvoiceListNew.sql
@@ -23,9 +23,10 @@
 	10    20/July/2026			 RAJESH GAMI						[PN-17350] - Removed IsNonStock=0 filter(s) so Non-Stock parts appear/populate correctly on SO billing/invoicing lists (WorkOrder branch untouched).
 	11    23/July/2026			 RAJESH GAMI						[PN-17350] - Removed leftover IsNonStock=0 exclusion filter(s) added during PN-17008/PN-17009 transitional Non-Stock merge phase (Non-Stock is now merged; filter no longer needed).
 	12    31/July/2026			 Moin Bloch							[PN-17513] - Include Service/Non-Stock parts in SO billing list even when @AllowBillingBeforeShipping = 0 and no shipment has been done, since these items are never physically shipped.
+	13    05/Aug/2026			 Kishor Makwana						Stopped hardcoding ItemNo to 0 in the SO blocks (now uses sop.SequenceNumber), so duplicate Part+Condition lines are distinguishable in the billing list; these blocks already group/dedupe by the real SalesOrderPartId.
 **************************************************************/
 --   EXEC [dbo].[GetCommonBillingInvoiceListNew] 706, 0,10
-CREATE     PROCEDURE [dbo].[GetCommonBillingInvoiceListNew]
+CREATE    PROCEDURE [dbo].[GetCommonBillingInvoiceListNew]
 @ReferenceId BIGINT = NULL,
 @SubReferenceId BIGINT = NULL, 
 @ModuleId INT = NULL
@@ -287,7 +288,7 @@ BEGIN
 				BEGIN 
 					INSERT INTO #InvoiceMainDetails(ReferenceNumber,partnumber,ItemMasterId,PartDescription,ConditionId,Condition,ReferenceId,SubReferenceId,Status,ItemNo,CustomerId,[BillingAmount],[PerformaBillingAmount])
 					(
-					SELECT DISTINCT so.SalesOrderNumber, imt.partnumber,imt.ItemMasterId, imt.PartDescription, sop.ConditionId, cond.Description as 'Condition', sop.SalesOrderId,sop.SalesOrderPartId, '' as [Status],	0 AS ItemNo,so.CustomerId
+					SELECT DISTINCT so.SalesOrderNumber,CAST(sop.SequenceNumber as VARCHAR(10))+' - '+ imt.partnumber as partnumber,imt.ItemMasterId, imt.PartDescription, sop.ConditionId, cond.Description as 'Condition', sop.SalesOrderId,sop.SalesOrderPartId, '' as [Status],	sop.SequenceNumber AS ItemNo,so.CustomerId
 					,(SELECT SUM(ISNULL(WOBI.[GrandTotal],0)) 
 						        FROM [dbo].[BillingInvoicing] WOB WITH(NOLOCK) 
 								INNER JOIN [dbo].[BillingInvoicingItems] WOBI WITH(NOLOCK) ON WOB.[BillingInvoicingId] = WOBI.[BillingInvoicingId] 
@@ -319,12 +320,12 @@ BEGIN
 					LEFT JOIN DBO.Condition cond WITH (NOLOCK) on cond.ConditionId = sop.ConditionId 
 					WHERE sop.SalesOrderId = @ReferenceId AND ISNULL(stk.StockLineId, 0) > 0
 					GROUP BY so.SalesOrderNumber, imt.partnumber,imt.ItemMasterId, imt.PartDescription,
-					sop.SalesOrderId, imt.ItemMasterId, sop.ConditionId,cond.Description, sop.SalesOrderPartId,so.CustomerId)
+					sop.SalesOrderId, imt.ItemMasterId, sop.ConditionId,cond.Description, sop.SalesOrderPartId,so.CustomerId,sop.SequenceNumber)
 
 					-- Service / Non-Stock parts are never physically shipped, so include them even when no shipment has been done
 					INSERT INTO #InvoiceMainDetails(ReferenceNumber,partnumber,ItemMasterId,PartDescription,ConditionId,Condition,ReferenceId,SubReferenceId,Status,ItemNo,CustomerId,[BillingAmount],[PerformaBillingAmount])
 					(
-					SELECT DISTINCT so.SalesOrderNumber, im.partnumber,im.ItemMasterId, im.PartDescription, sop.ConditionId, cond.Description as 'Condition', sop.SalesOrderId,sop.SalesOrderPartId, '' as [Status],	0 AS ItemNo,so.CustomerId
+					SELECT DISTINCT so.SalesOrderNumber,CAST(sop.SequenceNumber as VARCHAR(10))+' - '+ im.partnumber as partnumber,im.ItemMasterId, im.PartDescription, sop.ConditionId, cond.Description as 'Condition', sop.SalesOrderId,sop.SalesOrderPartId, '' as [Status],	sop.SequenceNumber AS ItemNo,so.CustomerId
 					,(SELECT SUM(ISNULL(WOBI.[GrandTotal],0))
 						        FROM [dbo].[BillingInvoicing] WOB WITH(NOLOCK)
 								INNER JOIN [dbo].[BillingInvoicingItems] WOBI WITH(NOLOCK) ON WOB.[BillingInvoicingId] = WOBI.[BillingInvoicingId]
@@ -359,8 +360,8 @@ BEGIN
 					IF (@SalesOrderShippingId > 0)
 					BEGIN 					
 						INSERT INTO #InvoiceMainDetails(ReferenceNumber,partnumber,ItemMasterId,PartDescription,ConditionId,Condition,ReferenceId,SubReferenceId,Status,ItemNo,CustomerId,[BillingAmount],[PerformaBillingAmount])
-						(SELECT DISTINCT so.SalesOrderNumber, imt.partnumber,imt.ItemMasterId, imt.PartDescription, sop.ConditionId, cond.Description as 'Condition',				
-						sop.SalesOrderId, sop.SalesOrderPartId AS SubReferenceId,	'' as [Status], 0 AS ItemNo,so.CustomerId
+						(SELECT DISTINCT so.SalesOrderNumber,CAST(sop.SequenceNumber as VARCHAR(10))+' - '+ imt.partnumber as partnumber,imt.ItemMasterId, imt.PartDescription, sop.ConditionId, cond.Description as 'Condition',				
+						sop.SalesOrderId, sop.SalesOrderPartId AS SubReferenceId,	'' as [Status], sop.SequenceNumber AS ItemNo,so.CustomerId
 						,(SELECT SUM(ISNULL(WOBI.[GrandTotal],0)) 
 						        FROM [dbo].[BillingInvoicing] WOB WITH(NOLOCK) 
 								INNER JOIN [dbo].[BillingInvoicingItems] WOBI WITH(NOLOCK) ON WOB.[BillingInvoicingId] = WOBI.[BillingInvoicingId] 
@@ -395,13 +396,13 @@ BEGIN
 						WHERE sop.SalesOrderId = @ReferenceId AND ISNULL(stk.StockLineId, 0) > 0
 						AND (ISNULL(soapr.SalesOrderApprovalId, 0) > 0 OR ISNULL(sosi.QtyShipped, 0) > 0) 
 						GROUP BY so.SalesOrderNumber, imt.partnumber, imt.ItemMasterId, imt.PartDescription,
-						sop.SalesOrderId, imt.ItemMasterId, sop.SalesOrderPartId, sop.ConditionId,cond.Description,so.CustomerId)
+						sop.SalesOrderId, imt.ItemMasterId, sop.SalesOrderPartId, sop.ConditionId,cond.Description,so.CustomerId,sop.SequenceNumber)
 					END
 					ELSE 
 					BEGIN						
 						INSERT INTO #InvoiceMainDetails(ReferenceNumber,partnumber,ItemMasterId,PartDescription,ConditionId,Condition,ReferenceId,SubReferenceId,Status,ItemNo,CustomerId,[BillingAmount],[PerformaBillingAmount])
-						(SELECT DISTINCT so.SalesOrderNumber, imt.partnumber, imt.ItemMasterId, imt.PartDescription, sop.ConditionId, cond.Description as 'Condition',				
-						sop.SalesOrderId,sop.SalesOrderPartId AS SubReferenceId,'' as [Status],0 AS ItemNo,so.CustomerId
+						(SELECT DISTINCT so.SalesOrderNumber,CAST(sop.SequenceNumber as VARCHAR(10))+' - '+ imt.partnumber as partnumber, imt.ItemMasterId, imt.PartDescription, sop.ConditionId, cond.Description as 'Condition',				
+						sop.SalesOrderId,sop.SalesOrderPartId AS SubReferenceId,'' as [Status],sop.SequenceNumber AS ItemNo,so.CustomerId
 						,(SELECT SUM(ISNULL(WOBI.[GrandTotal],0)) 
 						        FROM [dbo].[BillingInvoicing] WOB WITH(NOLOCK) 
 								INNER JOIN [dbo].[BillingInvoicingItems] WOBI WITH(NOLOCK) ON WOB.[BillingInvoicingId] = WOBI.[BillingInvoicingId] 
@@ -437,7 +438,7 @@ BEGIN
 						AND ((ISNULL(soapr.SalesOrderApprovalId, 0) > 0   
 						AND (ISNULL(SOR.SalesOrderReservePartId, 0) > 0) AND (ISNULL(SOR.TotalReserved, 0) > 0)) OR ISNULL(sosi.QtyShipped, 0) > 0)
 						GROUP BY so.SalesOrderNumber, imt.partnumber, imt.ItemMasterId, imt.PartDescription,
-						sop.SalesOrderId, imt.ItemMasterId, sop.ConditionId,cond.Description, sop.SalesOrderPartId,so.CustomerId)
+						sop.SalesOrderId, imt.ItemMasterId, sop.ConditionId,cond.Description, sop.SalesOrderPartId,so.CustomerId,sop.SequenceNumber)
 					END
 				END
 
@@ -481,8 +482,8 @@ BEGIN
 										sop.SalesOrderId, 
 										sop.SalesOrderPartId As SubReferenceId,
 										'' AS [Status],
-										0 AS ItemNo,
-										so.CustomerId,										
+										sop.SequenceNumber AS ItemNo,
+										so.CustomerId,
 									   (SELECT SUM(ISNULL(WOBI.[GrandTotal],0)) 
 										FROM [dbo].[BillingInvoicing] WOB WITH(NOLOCK) 
 										INNER JOIN [dbo].[BillingInvoicingItems] WOBI WITH(NOLOCK) ON WOB.[BillingInvoicingId] = WOBI.[BillingInvoicingId] 
@@ -506,7 +507,7 @@ BEGIN
 									LEFT JOIN DBO.Condition cond WITH (NOLOCK) on cond.ConditionId = sop.ConditionId
 								
 								WHERE sop.SalesOrderId = @ReferenceId AND sop.ItemMasterId = @ItemMasterId AND sop.ConditionId = @ConditionId AND  sop.SalesOrderPartId = @SalesOrderPartId
-								 GROUP BY so.SalesOrderNumber, imt.partnumber,imt.ItemMasterId, imt.PartDescription,sop.SalesOrderId,  imt.ItemMasterId, sop.SalesOrderPartId, sop.ConditionId,cond.Description,so.CustomerId)
+								 GROUP BY so.SalesOrderNumber, imt.partnumber,imt.ItemMasterId, imt.PartDescription,sop.SalesOrderId,  imt.ItemMasterId, sop.SalesOrderPartId, sop.ConditionId,cond.Description,so.CustomerId,sop.SequenceNumber)
 					END
 					
 					SET @COUNT = @COUNT - 1

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetCommonBillingMPNDetails.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetCommonBillingMPNDetails.sql
@@ -33,10 +33,11 @@
 	20   05/JUNE/2026 Rajesh Gami		Skip the IsFinishGood = 1 condition when the Work Order type is Teardown.[PN-16719]
 	21   09/July/2026 RAJESH GAMI		[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	22   20/July/2026 RAJESH GAMI		[PN-17350] - Removed IsNonStock=0 filter so Non-Stock parts' MPN details populate correctly on SO billing (WorkOrder branch untouched).
+	23	 05/Aug/2026 Kishor Makwana		Removed the unused LEFT JOINs to SalesOrderPartCost (PC) and SalesOrderStockLineCost (SOSC) in the SO stockline insert - neither table's columns were selected there, but when either had more than one matching row (e.g. cost revision history) the JOIN silently duplicated the SalesOrderStocklineV1 row into two grid rows with the same PN/Condition/StockLineNum/Qty but different Total Cost.
 --  EXEC [dbo].[GetCommonBillingMPNDetails] 926,1166,'1166',10,0,1
     EXEC [dbo].[GetCommonBillingMPNDetails] 19821,19957,'19957',15,1,0
 ************************************************************************/
-CREATE   PROCEDURE [dbo].[GetCommonBillingMPNDetails]
+CREATE    PROCEDURE [dbo].[GetCommonBillingMPNDetails]
 @ReferenceId BIGINT=NULL,
 @SubReferenceId BIGINT=NULL,
 @SubReferenceIds VARCHAR(200)=NULL,
@@ -548,11 +549,11 @@ BEGIN
 								, CASE WHEN ISNULL(STK.SalesOrderStocklineId,0) = 0 THEN con.[Description] ELSE COND.[Description] END,
 						SOP.[PartNumber],[PartDescription],SL.[Manufacturer],SL.[SerialNumber],STK.SalesOrderStocklineId,CASE WHEN ISNULL(STK.SalesOrderStocklineId,0) = 0 THEN SOP.QtyOrder ELSE STK.QtyOrder END,Sl.StockLineNumber,SHIPPINGINFO.SalesOrderShippingId
 
-			FROM [dbo].[SalesOrderPartV1] SOP WITH(NOLOCK) 
-				 LEFT JOIN dbo.SalesOrderPartCost PC WITH (NOLOCK) ON SOP.SalesOrderPartId = PC.SalesOrderPartId 
-				 LEFT JOIN dbo.SalesOrderStocklineV1 STK WITH (NOLOCK) ON STK.SalesOrderPartId = SOP.SalesOrderPartId 
-				 LEFT JOIN DBO.SalesOrderStockLineCost SOSC WITH (NOLOCK) ON SOSC.SalesOrderStocklineId = stk.SalesOrderStocklineId				
-				 LEFT JOIN DBO.Stockline sl WITH (NOLOCK) ON sl.StockLineId = stk.StockLineId  
+			FROM [dbo].[SalesOrderPartV1] SOP WITH(NOLOCK)
+				 --LEFT JOIN dbo.SalesOrderPartCost PC WITH (NOLOCK) ON SOP.SalesOrderPartId = PC.SalesOrderPartId
+				 LEFT JOIN dbo.SalesOrderStocklineV1 STK WITH (NOLOCK) ON STK.SalesOrderPartId = SOP.SalesOrderPartId
+				 --LEFT JOIN DBO.SalesOrderStockLineCost SOSC WITH (NOLOCK) ON SOSC.SalesOrderStocklineId = stk.SalesOrderStocklineId
+				 LEFT JOIN DBO.Stockline sl WITH (NOLOCK) ON sl.StockLineId = stk.StockLineId
 				 LEFT JOIN [dbo].[Condition] COND WITH(NOLOCK) ON STK.[ConditionId] = COND.[ConditionId]
 				 LEFT JOIN [dbo].[Condition] con WITH(NOLOCK) ON SOP.[ConditionId] = con.[ConditionId]
 				  OUTER APPLY (

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetPartsViewBySalesOrderId.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetPartsViewBySalesOrderId.sql
@@ -28,10 +28,10 @@
 	12    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	13    09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	14    20/July/2026			 RAJESH GAMI						[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filters from part join and WHERE clause.
-
+	15    06/Aug/2026			 KISHOR MAKWANA						[PN-17439] - Concate Sequence Number With Part.
 EXEC [dbo].[GetPartsViewBySalesOrderId]  879
 **************************************************************/
-CREATE   PROCEDURE [dbo].[GetPartsViewBySalesOrderId]
+CREATE    PROCEDURE [dbo].[GetPartsViewBySalesOrderId]
     @SalesOrderId INT
 AS
 BEGIN
@@ -126,7 +126,7 @@ BEGIN
 			part.CreatedDate createdDate,
 			part.UpdatedBy updatedBy,
 			part.UpdatedDate updatedDate,
-			itemMaster.PartNumber partNumber,
+			CAST(part.SequenceNumber AS VARCHAR(10)) +' - '+ itemMaster.PartNumber AS partNumber,
 			itemMaster.PartDescription partDescription,
 			itemMaster.IsOEM isOEM,
 			itemMaster.IsPMA AS isPMA,
@@ -199,7 +199,7 @@ BEGIN
 			--						AND b.ItemMasterId = part.ItemMasterId AND b.ConditionId = part.ConditionId), 0)
 			--		END
 			--	END AS freight,
-			ISNULL((SELECT SUM(b.Amount) FROM DBO.SalesOrderFreight b WITH (NOLOCK) WHERE b.SalesOrderId = @SalesOrderId AND b.IsActive = 1 AND b.IsDeleted = 0 AND b.ItemMasterId = part.ItemMasterId AND b.ConditionId = part.ConditionId), 0) AS freight,
+			ISNULL((SELECT SUM(b.Amount) FROM DBO.SalesOrderFreight b WITH (NOLOCK) WHERE b.SalesOrderId = @SalesOrderId AND b.IsActive = 1 AND b.IsDeleted = 0 AND b.ItemMasterId = part.ItemMasterId AND b.ConditionId = part.ConditionId AND b.SalesOrderPartId=part.SalesOrderPartId), 0) AS freight,
 			0 AS sobillingInvoicingItemId,
 			@IsInvoiceGenerated isInvoiceGenerated,
 			CASE WHEN SOSC.SalesOrderStocklineId IS NOT NULL THEN ISNULL(SOSC.NetSaleAmountPerUnit, 0) ELSE ISNULL(SOPC.NetSaleAmountPerUnit, 0) END AS netSalesPricePerUnit
@@ -225,7 +225,7 @@ BEGIN
 	    LEFT JOIN DBO.SalesOrderApproval sp WITH (NOLOCK) ON part.SalesOrderPartId = sp.SalesOrderPartId AND sp.SalesOrderId = @SalesOrderId AND sp.IsDeleted = 0 AND sp.IsActive =1
 		LEFT JOIN DBO.BillingInvoicingItems sob WITH (NOLOCK) ON part.SalesOrderPartId = sob.SubReferenceId AND stk.StockLineId = sob.StockLineId AND ISNULL(sob.IsVersionIncrease,0) = 0 AND ISNULL(sob.IsPerformaInvoice,0) = 0  AND sob.[ModuleId] =@SOModuleId
 		LEFT JOIN DBO.BillingInvoicing sbi WITH (NOLOCK) ON sob.BillingInvoicingId = sbi.BillingInvoicingId AND sbi.ReferenceId = @SalesOrderId AND ISNULL(sbi.IsPerformaInvoice,0) = 0 AND sbi.[ModuleId] =@SOModuleId
-		LEFT JOIN DBO.SalesOrderFreight f WITH (NOLOCK) ON so.SalesOrderId = f.SalesOrderId AND f.ItemMasterId = part.ItemMasterId AND f.ConditionId = part.ConditionId AND f.IsActive = 1 AND f.IsDeleted = 0
+		LEFT JOIN DBO.SalesOrderFreight f WITH (NOLOCK) ON so.SalesOrderId = f.SalesOrderId AND f.ItemMasterId = part.ItemMasterId AND f.ConditionId = part.ConditionId AND f.SalesOrderPartId = part.SalesOrderPartId AND f.IsActive = 1 AND f.IsDeleted = 0
 		LEFT JOIN DBO.SalesOrderCharges ch WITH (NOLOCK) ON so.SalesOrderId = ch.SalesOrderId AND ch.ItemMasterId = part.ItemMasterId AND ch.ConditionId = part.ConditionId AND ch.IsActive = 1 AND ch.IsDeleted = 0
 		LEFT JOIN #TempTaxAmount t ON part.SalesOrderPartId = t.PartId
 		WHERE part.SalesOrderId = @SalesOrderId AND part.IsDeleted = 0 ;

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderFreightList.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderFreightList.sql
@@ -20,7 +20,7 @@
     1    28/02/2025  Ekta Chandegra		Created    
 	2    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	3    20/July/2026			 RAJESH GAMI						[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filter from ItemMaster join.
-         
+    4    11/Aug/2026			 Kishor Makwana						[PN-17439]  - Concate Sequence Number in  ItemNo 
 -- EXEC GetSalesOrderFreightList 915 ,0
 ************************************************************************/   
 CREATE     PROCEDURE [dbo].[GetSalesOrderFreightList]
@@ -66,7 +66,7 @@ BEGIN
 				sf.CurrencyName,
 				im.PartNumber,
 				sf.ItemMasterId,
-				(im.PartNumber + ' - ' + cond.Description) AS ItemNo,
+				(CAST(part.SequenceNumber as VARCHAR(10))  + ' - ' +  im.PartNumber + ' - ' + cond.Description) AS ItemNo,
 				im.PartNumber AS Pn,
 				part.ConditionId
 			FROM [dbo].[SalesOrderQuoteFreight] sf WITH(NOLOCK)

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderPartView.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderPartView.sql
@@ -1,4 +1,4 @@
-/*************************************************************           
+﻿/*************************************************************           
  ** File:   [GetSalesOrderPartView]           
  ** Author:   Vishal Suthar
  ** Description: This stored procedure is used to get Sales Order Quote Part Data
@@ -37,6 +37,7 @@
 	24    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	25    09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	26    20/July/2026			 RAJESH GAMI						[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filters from QtyAvailable/QuantityOnHand rollup subqueries and StockLine/ItemMaster joins.
+    27    05/Aug/2026			 KISHOR MAKWANA						[PN-17439] Return persisted part.SequenceNumber as ItemNo instead of hardcoded 0
 -- EXEC [DBO].[GetSalesOrderPartView] 706,0
 **************************************************************/
 CREATE   PROCEDURE [dbo].[GetSalesOrderPartView]
@@ -53,17 +54,127 @@ BEGIN
 	DECLARE @DefaultStatusId INT = 1;
 	DECLARE @DefaultStatusName VARCHAR(50) = 'OPEN';
 	DECLARE @soModuleId INT = (SELECT TOP 1 ModuleId FROM dbo.Module WITH(NOLOCK) WHERE ModuleName = 'SalesOrder')
-	DECLARE @LOTNumber VARCHAR(100)= ISNULL((SELECT LotNumber FROM dbo.LOT WITH(NOLOCK) WHERE LotId = (SELECT ISNULL(LotId,0) FROM dbo.SalesOrder WITH(NOLOCK) WHERE SalesOrderId = @SalesOrderId)),'')
+	DECLARE @LotId BIGINT = ISNULL((SELECT TOP 1 ISNULL(LotId,0) FROM dbo.SalesOrder WITH(NOLOCK) WHERE SalesOrderId = @SalesOrderId),0)
+	DECLARE @LOTNumber VARCHAR(100)= ISNULL((SELECT TOP 1 LotNumber FROM dbo.LOT WITH(NOLOCK) WHERE LotId = @LotId),'')
 	--Set SoPart null for all part for salesordor otherwise for perticular part only.
 	IF(ISNULL(@SoPartId,0) = 0)
 	BEGIN
 		SET @SoPartId = NULL;
 	END
-
 		IF OBJECT_ID(N'tempdb..#tmpSOPartTblV1') IS NOT NULL
 		BEGIN
 			DROP TABLE #tmpSOPartTblV1
 		END
+		IF OBJECT_ID(N'tempdb..#SOPartKey')   IS NOT NULL DROP TABLE #SOPartKey
+		IF OBJECT_ID(N'tempdb..#StkRollup')   IS NOT NULL DROP TABLE #StkRollup
+		IF OBJECT_ID(N'tempdb..#PickTicket')  IS NOT NULL DROP TABLE #PickTicket
+		IF OBJECT_ID(N'tempdb..#FreightAgg')  IS NOT NULL DROP TABLE #FreightAgg
+		IF OBJECT_ID(N'tempdb..#MiscAgg')     IS NOT NULL DROP TABLE #MiscAgg
+		IF OBJECT_ID(N'tempdb..#ApprovedPart') IS NOT NULL DROP TABLE #ApprovedPart
+		IF OBJECT_ID(N'tempdb..#ShippedAgg')  IS NOT NULL DROP TABLE #ShippedAgg
+		IF OBJECT_ID(N'tempdb..#ShipRef')     IS NOT NULL DROP TABLE #ShipRef
+		IF OBJECT_ID(N'tempdb..#BillingAgg')  IS NOT NULL DROP TABLE #BillingAgg
+		IF OBJECT_ID(N'tempdb..#LotStk')      IS NOT NULL DROP TABLE #LotStk
+
+	/****** PRE-AGGREGATION : each block replaces a correlated sub-query that previously ran once PER ROW ******/
+
+	-- Scope key for this execution
+	SELECT DISTINCT p.SalesOrderPartId, p.ItemMasterId, p.ConditionId,p.SequenceNumber
+	INTO #SOPartKey
+	FROM DBO.SalesOrderPartV1 p WITH (NOLOCK)
+	WHERE p.SalesOrderId = @SalesOrderId
+	  AND (@SoPartId IS NULL OR p.SalesOrderPartId = @SoPartId)
+	  AND (p.IsDeleted IS NULL OR p.IsDeleted = 0)
+	OPTION (RECOMPILE);
+	CREATE CLUSTERED INDEX IX_SOPartKey ON #SOPartKey (ItemMasterId, ConditionId, SalesOrderPartId,SequenceNumber);
+
+	-- Stockline roll-up by ItemMasterId + ConditionId  (was written 4x and executed 4x per row)
+	SELECT k.ItemMasterId, k.ConditionId,k.SequenceNumber, s.QtyAvailable, s.QtyOnHand
+	INTO #StkRollup
+	FROM (SELECT DISTINCT ItemMasterId, ConditionId,SequenceNumber FROM #SOPartKey) k
+	CROSS APPLY (SELECT SUM(Stk.QuantityAvailable) AS QtyAvailable, SUM(Stk.QuantityOnHand) AS QtyOnHand
+				 FROM DBO.Stockline Stk WITH (NOLOCK)
+				 WHERE Stk.ItemMasterId = k.ItemMasterId AND Stk.ConditionId = k.ConditionId AND Stk.IsParent = 1
+				   AND ((Stk.IsRepairManagement = 1) OR ((Stk.IsRepairManagement = 0 OR Stk.IsRepairManagement IS NULL) AND Stk.IsCustomerStock = 0))) s;
+	CREATE CLUSTERED INDEX IX_StkRollup ON #StkRollup (ItemMasterId, ConditionId,SequenceNumber);
+
+	-- QtyToShip
+	SELECT SalesOrderPartId, QtyToShip = SUM(QtyToShip)
+	INTO #PickTicket
+	FROM DBO.SOPickTicket WITH (NOLOCK)
+	WHERE SalesOrderId = @SalesOrderId AND IsActive = 1 AND IsDeleted = 0
+	GROUP BY SalesOrderPartId;
+	CREATE CLUSTERED INDEX IX_PickTicket ON #PickTicket (SalesOrderPartId);
+
+	-- Freight
+	SELECT ItemMasterId, ConditionId, Freight = SUM(BillingAmount)
+	INTO #FreightAgg
+	FROM DBO.SalesOrderFreight WITH (NOLOCK)
+	WHERE SalesOrderId = @SalesOrderId AND IsActive = 1 AND IsDeleted = 0
+	GROUP BY ItemMasterId, ConditionId;
+	CREATE CLUSTERED INDEX IX_FreightAgg ON #FreightAgg (ItemMasterId, ConditionId);
+
+	-- Misc charges
+	SELECT ItemMasterId, ConditionId, Misc = SUM(BillingAmount)
+	INTO #MiscAgg
+	FROM DBO.SalesOrderCharges WITH (NOLOCK)
+	WHERE SalesOrderId = @SalesOrderId AND IsActive = 1 AND IsDeleted = 0
+	GROUP BY ItemMasterId, ConditionId;
+	CREATE CLUSTERED INDEX IX_MiscAgg ON #MiscAgg (ItemMasterId, ConditionId);
+
+	-- IsApproved  (was EXISTS per row)
+	SELECT DISTINCT sa.SalesOrderPartId
+	INTO #ApprovedPart
+	FROM DBO.SalesOrderApproval sa WITH (NOLOCK)
+	INNER JOIN #SOPartKey k ON k.SalesOrderPartId = sa.SalesOrderPartId
+	WHERE sa.IsDeleted = 0 AND sa.CustomerStatusId = @ApprovedStatus;
+	CREATE CLUSTERED INDEX IX_ApprovedPart ON #ApprovedPart (SalesOrderPartId);
+
+	-- qtyShipped
+	SELECT sopt.SalesOrderPartStocklineId, qtyShipped = SUM(sosi.QtyShipped)
+	INTO #ShippedAgg
+	FROM DBO.SalesOrderShipping sos WITH (NOLOCK)
+	INNER JOIN DBO.SalesOrderShippingItem sosi WITH (NOLOCK) ON sos.SalesOrderShippingId = sosi.SalesOrderShippingId
+	INNER JOIN DBO.SOPickTicket sopt WITH (NOLOCK) ON sopt.SOPickTicketId = sosi.SOPickTicketId
+	WHERE sos.SalesOrderId = @SalesOrderId AND sos.IsActive = 1 AND sos.IsDeleted = 0
+	GROUP BY sopt.SalesOrderPartStocklineId;
+	CREATE CLUSTERED INDEX IX_ShippedAgg ON #ShippedAgg (SalesOrderPartStocklineId);
+
+	-- shipReference
+	SELECT r.SalesOrderPartId, r.SOShippingNum
+	INTO #ShipRef
+	FROM (SELECT sosi.SalesOrderPartId, sos.SOShippingNum,
+				 rn = ROW_NUMBER() OVER (PARTITION BY sosi.SalesOrderPartId ORDER BY sos.SalesOrderShippingId)
+		  FROM DBO.SalesOrderShipping sos WITH (NOLOCK)
+		  INNER JOIN DBO.SalesOrderShippingItem sosi WITH (NOLOCK) ON sos.SalesOrderShippingId = sosi.SalesOrderShippingId
+		  WHERE sos.SalesOrderId = @SalesOrderId AND sos.IsActive = 1 AND sos.IsDeleted = 0) r
+	WHERE r.rn = 1;
+	CREATE CLUSTERED INDEX IX_ShipRef ON #ShipRef (SalesOrderPartId);
+
+	-- qtyInvoiced / invoiceDate / invoiceNumber  (was 3 separate scans per row)
+	SELECT b.StocklineId, b.SubReferenceId,
+		   qtyInvoiced   = SUM(b.QtyBilled),
+		   invoiceDate   = MAX(CASE WHEN b.rn = 1 THEN b.InvoiceDate END),
+		   invoiceNumber = MAX(CASE WHEN b.rn = 1 THEN b.InvoiceNo   END)
+	INTO #BillingAgg
+	FROM (SELECT sobi.StocklineId, sobi.SubReferenceId, sobi.QtyBilled, sob.InvoiceDate, sob.InvoiceNo,
+				 rn = ROW_NUMBER() OVER (PARTITION BY sobi.StocklineId, sobi.SubReferenceId ORDER BY sob.BillingInvoicingId)
+		  FROM DBO.BillingInvoicing sob WITH (NOLOCK)
+		  INNER JOIN DBO.BillingInvoicingItems sobi WITH (NOLOCK) ON sob.BillingInvoicingId = sobi.BillingInvoicingId
+		  WHERE sob.ModuleId = @soModuleId AND sob.ReferenceId = @SalesOrderId
+			AND ISNULL(sob.IsActive,0) = 1 AND ISNULL(sob.IsDeleted,0) = 0
+			AND ISNULL(sobi.IsVersionIncrease,0) = 0 AND ISNULL(sobi.IsPerformaInvoice,0) = 0) b
+	GROUP BY b.StocklineId, b.SubReferenceId;
+	CREATE CLUSTERED INDEX IX_BillingAgg ON #BillingAgg (StocklineId, SubReferenceId);
+
+	-- LotNumber
+	CREATE TABLE #LotStk (StockLineId BIGINT NOT NULL PRIMARY KEY);
+	IF (@LOTNumber <> '' AND @LotId > 0)
+	BEGIN
+		INSERT INTO #LotStk (StockLineId)
+		SELECT DISTINCT LTI.StockLineId FROM dbo.LotTransInOutDetails LTI WITH (NOLOCK)
+		WHERE LTI.LotId = @LotId AND LTI.StockLineId IS NOT NULL;
+	END
 
     SELECT DISTINCT
         part.SalesOrderId,
@@ -122,10 +233,7 @@ BEGIN
         --ISNULL(qs.QuantityOnHand, 0) AS QuantityOnHand,
         ISNULL(iu.ShortName, '') AS UOM,
         ISNULL(Stk.QtyReserved, NULL) AS QtyReserved,
-        CASE 
-            WHEN EXISTS (SELECT 1 FROM DBO.SalesOrderApproval WITH (NOLOCK) WHERE SalesOrderPartId = part.SalesOrderPartId AND IsDeleted = 0 AND CustomerStatusId = @ApprovedStatus) 
-            THEN 1 ELSE 0 
-        END AS IsApproved,
+        CASE WHEN appr.SalesOrderPartId IS NOT NULL THEN 1 ELSE 0 END AS IsApproved,
         ISNULL(SO.SalesOrderQuoteId, '') AS CustomerReference,
         --ISNULL(imx.ExportECCN, '') AS ECCN,
         ISNULL(imx.ITARNumber, '') AS ITAR,
@@ -136,8 +244,8 @@ BEGIN
 		CASE WHEN Stk.PriorityId IS NOT NULL THEN Stk.PriorityId ELSE ISNULL(part.PriorityId, @DefaultPriorityId) END AS PriorityId,
 		CASE WHEN Stk.PriorityId IS NOT NULL THEN prit.Description ELSE ISNULL(pri.Description, @DefaultPriorityName) END AS PriorityName,
 		CASE WHEN Stk.SalesOrderStocklineId IS NOT NULL THEN ISNULL(Stk.StatusId,@DefaultStatusId) ELSE ISNULL(part.StatusId,@DefaultStatusId) END StatusId,
-		ISNULL((SELECT Description FROM SOPartStatus WHERE SOPartStatusId = (CASE WHEN Stk.SalesOrderStocklineId IS NOT NULL THEN ISNULL(Stk.StatusId,@DefaultStatusId) ELSE ISNULL(part.StatusId,@DefaultStatusId) END )), @DefaultStatusName) AS StatusName,
-        ISNULL((SELECT SUM(QtyToShip) FROM DBO.SOPickTicket WHERE SalesOrderId = part.SalesOrderId AND SalesOrderPartId = part.SalesOrderPartId AND IsActive = 1 AND IsDeleted = 0), 0) AS QtyToShip,
+		ISNULL(sps.Description, @DefaultStatusName) AS StatusName,
+        ISNULL(pkt.QtyToShip, 0) AS QtyToShip,
         CASE WHEN Stk.SalesOrderStocklineId IS NOT NULL THEN Stk.Notes ELSE part.Notes END Notes,
         CASE WHEN SC.SalesOrderStocklineId IS NOT NULL THEN (CASE WHEN ISNULL(stk.QtyOrder,0) >0 THEN (ISNULL(SC.MarkUpAmount, 0) / stk.QtyOrder) ELSE 0 END) ELSE(CASE WHEN ISNULL(part.QtyOrder,0) > 0 THEN (ISNULL(PS.MarkUpAmount, 0) / part.QtyOrder) ELSE 0 END)END MarkupPerUnit,
         CASE WHEN SC.SalesOrderStocklineId IS NOT NULL THEN ISNULL(SC.NetSaleAmount, 0) ELSE ISNULL(PS.NetSaleAmount, 0) END AS GrossSalePricePerUnit,
@@ -145,16 +253,16 @@ BEGIN
         0 AS TaxPercentage,
         '' TaxType,
         ISNULL(PS.TaxAmount, 0) AS TaxAmount,
-        ISNULL(part.AltOrEqType,'') AltOrEqType,		
-        ISNULL((SELECT SUM(BillingAmount) FROM SalesOrderFreight WHERE SalesOrderId = part.SalesOrderId AND ItemMasterId = part.ItemMasterId AND ConditionId = part.ConditionId AND IsActive = 1 AND IsDeleted = 0), 0) AS Freight,
-        ISNULL((SELECT SUM(BillingAmount) FROM SalesOrderCharges WHERE SalesOrderId = part.SalesOrderId AND ItemMasterId = part.ItemMasterId AND ConditionId = part.ConditionId AND IsActive = 1 AND IsDeleted = 0), 0) AS Misc,
-        CASE 
+        ISNULL(part.AltOrEqType,'') AltOrEqType,
+        ISNULL(frt.Freight, 0) AS Freight,
+        ISNULL(msc.Misc, 0) AS Misc,
+        CASE
             WHEN itemMaster.IsPma = 1 AND itemMaster.IsDER = 1 THEN 'PMA&DER'
             WHEN itemMaster.IsPma = 1 THEN 'PMA'
             WHEN itemMaster.IsDER = 1 THEN 'DER'
             ELSE 'OEM'
         END AS StockType,
-        0 AS ItemNo,
+        part.SequenceNumber AS ItemNo,
         part.POId,
         part.PONumber,
         part.PONextDlvrDate,
@@ -166,50 +274,43 @@ BEGIN
         itemMaster.ItemGroup,
         rop.EstRecordDate AS roNextDlvrDate,
 		CASE WHEN Stk.SalesOrderStocklineId IS NOT NULL THEN
-			(SELECT ISNULL(SUM(Stkl.QuantityAvailable),0) FROM DBO.Stockline Stkl WITH (NOLOCK) WHERE Stkl.StockLineId = Stk.StockLineId) 
+			ISNULL(qs.QuantityAvailable, 0)
 		ELSE
-			(SELECT ISNULL(SUM(Stk.QuantityAvailable),0) FROM DBO.Stockline Stk WITH (NOLOCK) WHERE Stk.ItemMasterId = part.ItemMasterId AND Stk.ConditionId = part.ConditionId AND Stk.IsParent = 1 AND ((Stk.IsRepairManagement = 1) OR ((Stk.IsRepairManagement = 0 OR Stk.IsRepairManagement IS NULL) AND Stk.IsCustomerStock = 0))) 
+			ISNULL(srl.QtyAvailable, 0)
 		END StkQtyAvailable,
-		(SELECT ISNULL(SUM(Stk.QuantityAvailable),0) FROM DBO.Stockline Stk WITH (NOLOCK) WHERE Stk.ItemMasterId = part.ItemMasterId AND Stk.ConditionId = part.ConditionId AND Stk.IsParent = 1 AND ((Stk.IsRepairManagement = 1) OR ((Stk.IsRepairManagement = 0 OR Stk.IsRepairManagement IS NULL) AND Stk.IsCustomerStock = 0)))
+		ISNULL(srl.QtyAvailable, 0)
 		 QtyAvailable,
 		CASE WHEN Stk.SalesOrderStocklineId IS NOT NULL THEN
-			(SELECT ISNULL(SUM(Stkl.QuantityOnHand),0) FROM DBO.Stockline Stkl WITH (NOLOCK) WHERE Stkl.StockLineId = Stk.StockLineId) 
+			ISNULL(qs.QuantityOnHand, 0)
 		ELSE
-			(SELECT ISNULL(SUM(Stk.QuantityOnHand),0) FROM DBO.Stockline Stk WITH (NOLOCK) WHERE Stk.ItemMasterId = part.ItemMasterId AND Stk.ConditionId = part.ConditionId AND Stk.IsParent = 1 AND ((Stk.IsRepairManagement = 1) OR ((Stk.IsRepairManagement = 0 OR Stk.IsRepairManagement IS NULL) AND Stk.IsCustomerStock = 0))) 
+			ISNULL(srl.QtyOnHand, 0)
 		END StkQuantityOnHand,
-		(SELECT ISNULL(SUM(Stk.QuantityOnHand),0) FROM DBO.Stockline Stk WITH (NOLOCK) WHERE Stk.ItemMasterId = part.ItemMasterId AND Stk.ConditionId = part.ConditionId AND Stk.IsParent = 1 AND ((Stk.IsRepairManagement = 1) OR ((Stk.IsRepairManagement = 0 OR Stk.IsRepairManagement IS NULL) AND Stk.IsCustomerStock = 0)))
+		ISNULL(srl.QtyOnHand, 0)
 		 QuantityOnHand,
-		(SELECT SUM(sosi.QtyShipped) FROM DBO.SalesOrderShipping sos WITH (NOLOCK) 
-		LEFT JOIN DBO.SalesOrderShippingItem sosi WITH (NOLOCK) ON sos.SalesOrderShippingId = sosi.SalesOrderShippingId
-		LEFT JOIN DBO.SOPickTicket sopt WITH (NOLOCK) ON sopt.SOPickTicketId = sosi.SOPickTicketId
-		WHERE sos.SalesOrderId = @SalesOrderId AND sopt.SalesOrderPartStocklineId = Stk.SalesOrderStocklineId AND sos.IsActive = 1 AND sos.IsDeleted = 0) qtyShipped,
-		
-		(SELECT SUM(sobi.QtyBilled) FROM DBO.BillingInvoicing sob WITH (NOLOCK) LEFT JOIN DBO.BillingInvoicingItems sobi WITH (NOLOCK) ON sob.BillingInvoicingId = sobi.BillingInvoicingId
-		WHERE sob.ModuleId = @soModuleId AND sob.ReferenceId = @SalesOrderId AND sobi.StocklineId = stk.StockLineId AND sobi.SubReferenceId = part.SalesOrderPartId AND ISNULL(sob.IsActive,0) = 1 AND ISNULL(sob.IsDeleted,0) = 0 AND ISNULL(sobi.IsVersionIncrease,0) = 0 AND ISNULL(sobi.IsPerformaInvoice,0) = 0) qtyInvoiced,
-		
-		(SELECT TOP 1 sob.InvoiceDate FROM DBO.BillingInvoicing sob WITH (NOLOCK) LEFT JOIN DBO.BillingInvoicingItems sobi WITH (NOLOCK) ON sob.BillingInvoicingId = sobi.BillingInvoicingId
-		WHERE sob.ModuleId = @soModuleId AND sob.ReferenceId = @SalesOrderId AND sobi.StocklineId = stk.StockLineId AND  sobi.SubReferenceId = part.SalesOrderPartId AND ISNULL(sob.IsActive,0) = 1 AND ISNULL(sob.IsDeleted,0) = 0 AND ISNULL(sobi.IsVersionIncrease,0) = 0 AND ISNULL(sobi.IsPerformaInvoice,0) = 0) invoiceDate,
-		
-		(SELECT TOP 1 sob.InvoiceNo FROM DBO.BillingInvoicing sob WITH (NOLOCK) LEFT JOIN DBO.BillingInvoicingItems sobi WITH (NOLOCK) ON sob.BillingInvoicingId = sobi.BillingInvoicingId
-		WHERE sob.ModuleId = @soModuleId AND sob.ReferenceId = @SalesOrderId AND sobi.StocklineId = stk.StockLineId AND sobi.SubReferenceId = part.SalesOrderPartId AND ISNULL(sob.IsActive,0) = 1 AND ISNULL(sob.IsDeleted,0) = 0 AND ISNULL(sobi.IsVersionIncrease,0) = 0 AND ISNULL(sobi.IsPerformaInvoice,0) = 0) invoiceNumber,
-		
-		(SELECT TOP 1 sos.SOShippingNum FROM DBO.SalesOrderShipping sos WITH (NOLOCK) LEFT JOIN DBO.SalesOrderShippingItem sosi WITH (NOLOCK) ON sos.SalesOrderShippingId = sosi.SalesOrderShippingId
-		WHERE sos.SalesOrderId = @SalesOrderId AND sosi.SalesOrderPartId = part.SalesOrderPartId AND sos.IsActive = 1 AND sos.IsDeleted = 0) shipReference,
+		shp.qtyShipped qtyShipped,
+
+		bil.qtyInvoiced qtyInvoiced,
+
+		bil.invoiceDate invoiceDate,
+
+		bil.invoiceNumber invoiceNumber,
+
+		sref.SOShippingNum shipReference,
 		CASE WHEN Stk.StockLineId IS NOT NULL THEN Stk.ECCN ELSE part.ECCN END ECCN,
 		CASE WHEN Stk.StockLineId IS NOT NULL THEN Stk.HSCODE ELSE part.HSCODE END HSCODE,
 		CASE WHEN Stk.StockLineId IS NOT NULL THEN Stk.[Weight] ELSE part.[Weight] END [Weight],
 		CASE WHEN Stk.StockLineId IS NOT NULL THEN Stk.SizeLength ELSE part.SizeLength END SizeLength,
 		CASE WHEN Stk.StockLineId IS NOT NULL THEN Stk.SizeWidth ELSE part.SizeWidth END SizeWidth,
 		CASE WHEN Stk.StockLineId IS NOT NULL THEN Stk.SizeHeight ELSE part.SizeHeight END SizeHeight,
-
 		(CASE WHEN ISNULL(part.ItemMasterId,0) != 0 AND ISNULL(part.ItemMasterId,0) != ISNULL(qs.ItemMasterId,0) THEN qs.PartNumber ELSE '' END) as RevisedPN,
 		(CASE WHEN ISNULL(part.ItemMasterId,0) != 0 AND ISNULL(part.ItemMasterId,0) != ISNULL(qs.ItemMasterId,0) THEN qs.ItemMasterId ELSE 0 END) as RevisedPNItemMasterId,
-		CASE WHEN @LOTNumber = '' THEN '' ELSE (CASE WHEN (SELECT LotId FROM dbo.LotTransInOutDetails LTI WHERE LTI.LotId = SO.LotId AND LTI.StockLineId = Stk.StockLineId ) >0 THEN @LOTNumber ELSE '' END) END  AS LotNumber,
+		CASE WHEN @LOTNumber = '' THEN '' ELSE (CASE WHEN lts.StockLineId IS NOT NULL THEN @LOTNumber ELSE '' END) END  AS LotNumber,
 		CASE WHEN SC.SalesOrderStocklineId IS NOT NULL THEN ISNULL(SC.NetSaleAmountPerUnit, 0) ELSE ISNULL(PS.NetSaleAmountPerUnit, 0) END AS netSalesPricePerUnit,
 		part.UnitSalesPrice MainUnitSalesPrice,
-		ISNULL((CASE WHEN SC.SalesOrderStocklineId IS NOT NULL THEN ISNULL(SC.NetSaleAmount, 0) ELSE ISNULL(PS.NetSaleAmount, 0) END), 0) NetSalePriceExtendedPart
-
-		INTO #tmpSOPartTblV1 
+		ISNULL((CASE WHEN SC.SalesOrderStocklineId IS NOT NULL THEN ISNULL(SC.NetSaleAmount, 0) ELSE ISNULL(PS.NetSaleAmount, 0) END), 0) NetSalePriceExtendedPart,
+		ISNULL(imps.SP_CalSPByPP_UnitSalePrice,0) AS ItemMasterUnitCost,
+		ISNULL(PS.NetSaleAmount,0) AS TotalPartCost
+		INTO #tmpSOPartTblV1
     FROM DBO.SalesOrderPartV1 part WITH (NOLOCK)
     LEFT JOIN DBO.SalesOrderStocklineV1 Stk WITH (NOLOCK) ON part.SalesOrderPartId = Stk.SalesOrderPartId
 	LEFT JOIN DBO.SalesOrderPartCost PS WITH (NOLOCK) ON PS.SalesOrderPartId = part.SalesOrderPartId
@@ -217,43 +318,55 @@ BEGIN
     LEFT JOIN DBO.SalesOrder SO WITH (NOLOCK) ON part.SalesOrderId = SO.SalesOrderId
     LEFT JOIN DBO.StockLine qs WITH (NOLOCK) ON Stk.StockLineId = qs.StockLineId
     LEFT JOIN DBO.ItemMaster itemMaster WITH (NOLOCK) ON part.ItemMasterId = itemMaster.ItemMasterId
-     LEFT JOIN DBO.ItemMasterExportInfo imx WITH (NOLOCK) ON itemMaster.ItemMasterId = imx.ItemMasterId
-    LEFT JOIN DBO.Manufacturer mf WITH (NOLOCK) ON itemMaster.ManufacturerId = mf.ManufacturerId
+    LEFT JOIN DBO.ItemMasterExportInfo imx WITH (NOLOCK) ON itemMaster.ItemMasterId = imx.ItemMasterId
     LEFT JOIN DBO.Condition cp WITH (NOLOCK) ON part.ConditionId = cp.ConditionId
 	LEFT JOIN DBO.SalesOrderQuotePartV1 SOQP WITH (NOLOCK) ON SOQP.SalesOrderQuotePartId = part.SalesOrderQuotePartId
     LEFT JOIN DBO.SalesOrderQuote q WITH (NOLOCK) ON SOQP.SalesOrderQuoteId = q.SalesOrderQuoteId
     LEFT JOIN DBO.UnitOfMeasure iu WITH (NOLOCK) ON itemMaster.ConsumeUnitOfMeasureId = iu.UnitOfMeasureId
     LEFT JOIN DBO.UnitOfMeasure um WITH (NOLOCK) ON itemMaster.PurchaseUnitOfMeasureId = um.UnitOfMeasureId
-    LEFT JOIN DBO.PurchaseOrder po WITH (NOLOCK) ON qs.PurchaseOrderId = po.PurchaseOrderId
     LEFT JOIN DBO.RepairOrder ro WITH (NOLOCK) ON qs.RepairOrderId = ro.RepairOrderId
     LEFT JOIN DBO.[Priority] pri WITH (NOLOCK) ON part.PriorityId = pri.PriorityId
     LEFT JOIN DBO.[Priority] prit WITH (NOLOCK) ON prit.PriorityId = Stk.PriorityId
-    LEFT JOIN DBO.RepairOrderPart rop WITH (NOLOCK) ON qs.RepairOrderPartRecordId = rop.RepairOrderPartRecordId AND ISNULL(ROP.[IsPiecePart], 0) = 0
+    LEFT JOIN DBO.RepairOrderPart rop WITH (NOLOCK) ON qs.RepairOrderPartRecordId = rop.RepairOrderPartRecordId AND (ROP.[IsPiecePart] IS NULL OR ROP.[IsPiecePart] = 0)
     LEFT JOIN DBO.Currency fcu WITH (NOLOCK) ON part.CurrencyId = fcu.CurrencyId AND fcu.IsActive = 1 AND fcu.IsDeleted = 0
-    WHERE part.SalesOrderId = @SalesOrderId 
+	/****** pre-aggregated lookups (replace the old per-row correlated sub-queries) ******/
+	LEFT JOIN #ApprovedPart appr ON appr.SalesOrderPartId = part.SalesOrderPartId
+	LEFT JOIN #PickTicket   pkt  ON pkt.SalesOrderPartId  = part.SalesOrderPartId
+	LEFT JOIN #FreightAgg   frt  ON frt.ItemMasterId = part.ItemMasterId AND frt.ConditionId = part.ConditionId
+	LEFT JOIN #MiscAgg      msc  ON msc.ItemMasterId = part.ItemMasterId AND msc.ConditionId = part.ConditionId
+	LEFT JOIN #StkRollup    srl  ON srl.ItemMasterId = part.ItemMasterId AND srl.ConditionId = part.ConditionId
+	LEFT JOIN #ShippedAgg   shp  ON shp.SalesOrderPartStocklineId = Stk.SalesOrderStocklineId
+	LEFT JOIN #ShipRef      sref ON sref.SalesOrderPartId = part.SalesOrderPartId
+	LEFT JOIN #BillingAgg   bil  ON bil.StocklineId = Stk.StockLineId AND bil.SubReferenceId = part.SalesOrderPartId
+	LEFT JOIN #LotStk       lts  ON lts.StockLineId = Stk.StockLineId
+	LEFT JOIN DBO.SOPartStatus sps WITH (NOLOCK) ON sps.SOPartStatusId = CASE WHEN Stk.SalesOrderStocklineId IS NOT NULL THEN ISNULL(Stk.StatusId,@DefaultStatusId) ELSE ISNULL(part.StatusId,@DefaultStatusId) END
+    LEFT JOIN ItemMasterPurchaseSale imps WITH (NOLOCK) ON imps.ItemMasterId = itemMaster.ItemMasterId and imps.ConditionId=part.ConditionId
+	WHERE part.SalesOrderId = @SalesOrderId
 	AND (@SoPartId IS NULL OR part.SalesOrderPartId = @SoPartId)
-    AND ISNULL(part.IsDeleted,0) = 0
-    AND ISNULL(rop.isAsset, 0) = 0
-	ORDER BY part.SalesOrderPartId;
+    AND (part.IsDeleted IS NULL OR part.IsDeleted = 0)
+    AND (rop.isAsset IS NULL OR rop.isAsset = 0)
+	ORDER BY part.SalesOrderPartId
+	OPTION (RECOMPILE);
+
+	CREATE CLUSTERED INDEX IX_tmpSOPartTblV1 ON #tmpSOPartTblV1 (SalesOrderPartId);
 
 	/****** Total Part Wise COST Calculation ******/
 	;WITH CTE_Cost AS (
-			SELECT 
+			SELECT
 				SalesOrderPartId,
 				SUM(ISNULL(Qty, 0)) AS TotalQtyQuoted,
 				SUM(ISNULL(NetSalePriceExtendedPart, 0)) AS TotalNetSalePriceExtended
 			FROM #tmpSOPartTblV1
 			GROUP BY SalesOrderPartId
 		)
-
 	/****** Final Table Return *******/
-		SELECT 
-			main.*,
-			(((main.QtyRequested - ISNULL(c.TotalQtyQuoted, 0)) * ISNULL(main.MainUnitSalesPrice, 0))
-			  + ISNULL(c.TotalNetSalePriceExtended, 0)) AS TotalPartCost
+		SELECT
+			main.*
+			--,
+			--(((main.QtyRequested - ISNULL(c.TotalQtyQuoted, 0)) * ISNULL(main.MainUnitSalesPrice, 0))
+			--  + ISNULL(c.TotalNetSalePriceExtended, 0)) AS TotalPartCost
 		FROM #tmpSOPartTblV1 main
-		LEFT JOIN CTE_Cost c ON main.SalesOrderPartId = c.SalesOrderPartId;
-
+		--LEFT JOIN CTE_Cost c ON main.SalesOrderPartId = c.SalesOrderPartId;
   END TRY
   BEGIN CATCH
   SELECT
@@ -271,7 +384,6 @@ BEGIN
                         @ProcedureParameters = @ProcedureParameters,
                         @ApplicationName = @ApplicationName,
                         @ErrorLogID = @ErrorLogID OUTPUT;
-
     RAISERROR ('Unexpected Error Occured in the database. Please let the support team know of the error number : %d', 16, 1, @ErrorLogID)
     RETURN (1);
   END CATCH

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderQuoteCharges.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderQuoteCharges.sql
@@ -20,6 +20,7 @@
     1    16/12/2024		EKTA CHANDEGRA	 Created  
 	2    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	3    20/July/2026			 RAJESH GAMI						[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filter from ItemMaster join.
+	4    11/Aug/2026			 Kishor Makwana						[PN-17439]  - Concate Sequence Number in  ItemNo 
 
  EXEC GetSalesOrderQuoteCharges 965 , 0
 ************************************************************************/  
@@ -62,7 +63,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 			im.PartNumber,
 			soc.ItemMasterId,
 			--part.ItemNo,
-			(im.PartNumber + ' - ' + cond.Description) AS ItemNo,
+			(CAST(part.SequenceNumber as VARCHAR(10))  + ' - ' +im.PartNumber + ' - ' + cond.Description) AS ItemNo,
 			im.PartNumber AS Pn,
 			part.ConditionId,
 			ISNULL(uom.ShortName, '') AS UOMName,

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderQuotePartView.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetSalesOrderQuotePartView.sql
@@ -1,4 +1,4 @@
-/*************************************************************           
+﻿/*************************************************************           
  ** File:   [GetSalesOrderQuotePartView]           
  ** Author:   Vishal Suthar
  ** Description: This stored procedure is used to get Sales Order Quote Part Data
@@ -26,9 +26,10 @@
 	12    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	13    09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	14    20/July/2026			 RAJESH GAMI						[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filters from QtyAvailable/QuantityOnHand rollup subqueries, StockLine join, and main WHERE clause.
+    15   10/Aug/2026			 KISHOR MAKWANA						[PN-17439] Return persisted part.SequenceNumber as ItemNo instead of hardcoded 0
  EXEC [DBO].[GetSalesOrderQuotePartView] 1653, 'USD'
 **************************************************************/
-CREATE PROCEDURE [dbo].[GetSalesOrderQuotePartView]
+CREATE   PROCEDURE [dbo].[GetSalesOrderQuotePartView]
     @SalesQuoteId BIGINT,
     @CurrencyDisplayName NVARCHAR(100) = ''
 AS
@@ -152,8 +153,7 @@ BEGIN
 			 QuantityOnHand,
 
 			part.IsConvertedToSalesOrder,
-			--ISNULL(part.ItemNo, 0) AS ItemNo,
-			0 AS ItemNo,
+			part.SequenceNumber AS ItemNo,
 			(CASE WHEN SC.SalesOrderQuoteStocklineId IS NOT NULL THEN SC.UnitSalesPrice ELSE PS.UnitSalesPrice END) UnitSalesPricePerUnit,
 			itemMaster.ItemClassificationName AS ItemClassification,
 			itemMaster.ItemGroup,

--- a/PAS_DB/dbo/Stored Procedures/Procs1/GetUnReservedStockPartsListBySOId.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/GetUnReservedStockPartsListBySOId.sql
@@ -94,7 +94,7 @@ BEGIN
 				ELSE 0 END AS NoofPieces
 		FROM [DBO].[SalesOrder] so WITH(NOLOCK)
 		JOIN [DBO].[SalesOrderPartV1] sop WITH(NOLOCK) ON so.SalesOrderId = sop.SalesOrderId
-		JOIN [DBO].[ItemMaster] im WITH(NOLOCK) ON sop.ItemMasterId = im.ItemMasterId AND ISNULL(im.[IsService],0) <> 1 AND ISNULL(im.[IsNonStock],0) <> 1
+		JOIN [DBO].[ItemMaster] im WITH(NOLOCK) ON sop.ItemMasterId = im.ItemMasterId AND (ISNULL(im.[IsService],0) <> 1 OR ISNULL(im.[IsNonStock],0) <> 1)
 		JOIN [DBO].[Customer] cu WITH(NOLOCK) ON so.CustomerId = cu.CustomerId
 		JOIN [DBO].[SalesOrderReserveParts] sopi WITH(NOLOCK) ON sop.SalesOrderPartId = sopi.SalesOrderPartId and sop.SalesOrderId = sopi.SalesOrderId
 		JOIN [DBO].[StockLine] stl WITH(NOLOCK) ON sopi.StockLineId = stl.StockLineId

--- a/PAS_DB/dbo/Stored Procedures/Procs1/ReallocateItemNo.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/ReallocateItemNo.sql
@@ -37,23 +37,25 @@ BEGIN
 			  ConditionId bigint,
 			  QtyRequested INT,
 			  qty INT,
+			  SequenceNumber BIGINT,
 			  LineId int NULL default 0
 			)
 
-			INSERT INTO #tmpSalesOrderPart(SalesOrderPartid,ItemMasterId,ConditionId,QtyRequested,qty)
-			SELECT SalesOrderPartId,ItemMasterId,ConditionId,QtyRequested,QtyOrder FROM dbo.SalesOrderPartV1 WITH (NOLOCK) Where SalesOrderId = @SalesOrderId AND IsDeleted = 0  order by SalesOrderPartId DESC
+			INSERT INTO #tmpSalesOrderPart(SalesOrderPartid,ItemMasterId,ConditionId,QtyRequested,qty,SequenceNumber)
+			SELECT SalesOrderPartId,ItemMasterId,ConditionId,QtyRequested,QtyOrder,SequenceNumber FROM dbo.SalesOrderPartV1 WITH (NOLOCK) Where SalesOrderId = @SalesOrderId AND IsDeleted = 0  order by SalesOrderPartId DESC
 
 			DECLARE  @MasterLoopID as BIGINT  = 0;
 			DECLARE  @ConditionID as BIGINT  = 0;
 			DECLARE  @ItemMasterID as BIGINT  = 0;
 			DECLARE  @RankID as BIGINT  = 0;
 			DECLARE  @QtyRequested as BIGINT  = 0;
+			DECLARE @SequenceNumber AS BIGINT =0;
 			
 			SELECT @MasterLoopID = MAX(ID) FROM #tmpSalesOrderPart
 
 			WHILE (@MasterLoopID > 0)
 			BEGIN	 
-				 SELECT  @ConditionID = ConditionId, @ItemMasterID = ItemMasterId, @QtyRequested = QtyRequested FROM #tmpSalesOrderPart WHERE ID = @MasterLoopID  
+				 SELECT  @ConditionID = ConditionId, @ItemMasterID = ItemMasterId, @QtyRequested = QtyRequested,@SequenceNumber =SequenceNumber  FROM #tmpSalesOrderPart WHERE ID = @MasterLoopID  
 
 				 IF EXISTS (SELECT ID FROM #tmpSalesOrderPart wHERE LineId = 0 AND ID = @MasterLoopID) 
 				 BEGIN
@@ -64,18 +66,19 @@ BEGIN
 				      SET LineId =  @RankID 
 					  FROM #tmpSalesOrderPart WHERE ConditionId = @ConditionID 
 					                          AND ItemMasterId = @ItemMasterID
+											  AND SequenceNumber = @SequenceNumber
 											  AND LineId = 0
 
-				If( (SELECT SUM(ISNULL(qty, 0)) FROM #tmpSalesOrderPart WHERE ConditionId = @ConditionID AND ItemMasterID = @ItemMasterId) > @QtyRequested)
+				If( (SELECT SUM(ISNULL(qty, 0)) FROM #tmpSalesOrderPart WHERE ConditionId = @ConditionID AND ItemMasterID = @ItemMasterId AND SequenceNumber= @SequenceNumber) > @QtyRequested)
 				BEGIN
 					UPDATE SalesOrderPartV1
 					SET QtyRequested = tmp.QtyRequested
 					FROM(
-						SELECT SUM(ISNULL(SOP.QtyOrder, 0)) AS QtyRequested, SalesOrderId, ConditionId, ItemMasterID
+						SELECT SUM(ISNULL(SOP.QtyOrder, 0)) AS QtyRequested, SalesOrderId, ConditionId, ItemMasterID,SequenceNumber
 						   FROM dbo.SalesOrderPartV1 SOP WITH(NOLOCK) 
-						   WHERE ConditionId = @ConditionID AND ItemMasterID = @ItemMasterId AND SalesOrderId = @SalesOrderId
-						   GROUP BY SalesOrderId, ConditionId, ItemMasterID
-					)tmp WHERE tmp.SalesOrderId = SalesOrderPartV1.SalesOrderId AND tmp.ItemMasterID = SalesOrderPartV1.ItemMasterID AND tmp.ConditionId = SalesOrderPartV1.ConditionId
+						   WHERE ConditionId = @ConditionID AND ItemMasterID = @ItemMasterId AND SalesOrderId = @SalesOrderId AND SequenceNumber=@SequenceNumber
+						   GROUP BY SalesOrderId, ConditionId, ItemMasterID,SequenceNumber
+					)tmp WHERE tmp.SalesOrderId = SalesOrderPartV1.SalesOrderId AND tmp.ItemMasterID = SalesOrderPartV1.ItemMasterID AND tmp.ConditionId = SalesOrderPartV1.ConditionId AND tmp.SequenceNumber= SalesOrderPartV1.SequenceNumber
 				END
 				
 				SET @MasterLoopID = @MasterLoopID - 1;

--- a/PAS_DB/dbo/Stored Procedures/Procs1/SalesOrderReserveUnReserveParts.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/SalesOrderReserveUnReserveParts.sql
@@ -21,6 +21,7 @@
 	5    13 DEC 2024  AMIT GHEDIYA		Add RefrenceNumber in stocktable.
 	6    17 DEC 2024   Shrey Chandegara  Add condition while execute USP_UpdateSOPartCostDetails this procedure 
 	7    08 JAN 2025   AMIT GHEDIYA		 Added one parameter to identify if it's been called from shipping or not
+	8    05 Aug 2026   Kishor Makwana	[PN-17439]	Scoped every SalesOrderPartV1/SalesOrderReserveParts lookup to the real per-line PK (SalesOrderPartId, already passed in) instead of ItemMasterId+ConditionId alone - two duplicate Part+Condition lines (different SequenceNumber) sharing a StockLineId were resolving to whichever line matched first, so Reserve/Unreserve wrote QtyReserved onto the wrong line and left the two lines' Qty Reserved/Qty Pending inconsistent (e.g. 2 / -2).
 
 declare @p1 dbo.SalesOrderReserveIssueParts
 insert into @p1 values(NULL,1357,1629,161088,119,N'3100454',N'SENSOR',NULL,NULL,0,NULL,NULL,0,5,2,2,N'OH',0,NULL,50,3,NULL,0,NULL,2,NULL,NULL,NULL,NULL,0,NULL,2,'2024-11-18 13:51:53.2864044',NULL,N'OEM',0,NULL,1,NULL,0,0,0,0,0,NULL,N'STL-000004',N'CNTL--001282',47,N'CASCO CIRCUITS INC',NULL,NULL,1,N'ADMIN User',N'ADMIN User','2024-11-18 13:51:53.2864029','2024-11-18 13:51:53.2864029',1,0)
@@ -28,7 +29,7 @@ insert into @p1 values(NULL,1357,1629,161083,119,N'3100454',N'SENSOR',NULL,NULL,
 
 exec dbo.SalesOrderReserveUnReserveParts @tbl_SalesOrderReserveIssueParts=@p1
 **************************************************************/
-CREATE   PROCEDURE [dbo].[SalesOrderReserveUnReserveParts] 
+CREATE    PROCEDURE [dbo].[SalesOrderReserveUnReserveParts] 
 (
 	@tbl_SalesOrderReserveIssueParts SalesOrderReserveIssueParts READONLY,
 	@afterShipping BIT,
@@ -249,7 +250,7 @@ BEGIN
 				--Checking for part data without stockline
 				IF NOT EXISTS(SELECT SOP.SalesOrderPartId FROM [DBO].[SalesOrderPartV1] SOP WITH(NOLOCK)
 					  LEFT JOIN [DBO].[SalesOrderStocklineV1] SOSP WITH(NOLOCK) ON SOSP.SalesOrderPartId = SOP.SalesOrderPartId
-					  WHERE SOP.SalesOrderId = @SalesOrderId AND SOSP.StockLineId = @StockLineId)
+					  WHERE SOP.SalesOrderId = @SalesOrderId AND SOP.SalesOrderPartId = @SalesOrderPartId AND SOSP.StockLineId = @StockLineId)
 				BEGIN 
 					DECLARE @QtyRequested BIGINT = NULL;
 					DECLARE @QtyAdded BIGINT = NULL;
@@ -280,7 +281,7 @@ BEGIN
 					FROM [DBO].[SalesOrderPartV1] SOP WITH(NOLOCK)
 					LEFT JOIN [DBO].[SalesOrderPartCost] SOPC WITH(NOLOCK) ON SOPC.SalesOrderPartId = SOP.SalesOrderPartId AND SOPC.SalesOrderId = SOP.SalesOrderId
 					WHERE SOP.SalesOrderId = @SalesOrderId AND SOP.ItemMasterId = @ItemMasterId
-					AND SOP.ConditionId = @ConditionId;
+					AND SOP.ConditionId = @ConditionId AND SOP.SalesOrderPartId = @SalesOrderPartId;
 
 					SELECT @QtyAdded = ISNULL(SUM(SOPS.QtyOrder), 0) FROM [DBO].[SalesOrderStocklineV1] SOPS WITH(NOLOCK) WHERE SOPS.SalesOrderPartId = @PartSalesOrderPartId;
 
@@ -338,14 +339,14 @@ BEGIN
 					--Checking for part data with stockline
 					IF EXISTS(SELECT TOP 1 1 FROM [DBO].[SalesOrderPartV1] SOP WITH(NOLOCK)
 						 LEFT JOIN [DBO].[SalesOrderStocklineV1] SOS WITH(NOLOCK) ON SOS.SalesOrderPartId = SOP.SalesOrderPartId
-						 WHERE SOP.SalesOrderId = @SalesOrderId AND SOS.StockLineId = @StockLineId)
+						 WHERE SOP.SalesOrderId = @SalesOrderId AND SOP.SalesOrderPartId = @SalesOrderPartId AND SOS.StockLineId = @StockLineId)
 					BEGIN
 						--Get Part Data
 						SELECT @PartSalesOrderPartId = SOP.SalesOrderPartId
 						FROM [DBO].[SalesOrderPartV1] SOP WITH(NOLOCK)
 						INNER JOIN [DBO].[SalesOrderPartCost] SOPC WITH(NOLOCK) ON SOPC.SalesOrderPartId = SOP.SalesOrderPartId AND SOPC.SalesOrderId = SOP.SalesOrderId
 						WHERE SOP.SalesOrderId = @SalesOrderId AND SOP.ItemMasterId = @ItemMasterId
-						AND SOP.ConditionId = @ConditionId;
+						AND SOP.ConditionId = @ConditionId AND SOP.SalesOrderPartId = @SalesOrderPartId;
 
 						--Update SO Part While Create Stockline On Reserve
 						--UPDATE [dbo].[SalesOrderPartV1]
@@ -373,14 +374,14 @@ BEGIN
 			
 			--Checking in ReservePart Table for add/update
 			IF EXISTS(SELECT TOP 1 1 FROM [DBO].[SalesOrderReserveParts] WITH(NOLOCK)
-					 WHERE StockLineId = @StockLineId AND SalesOrderId = @SalesOrderId AND ItemMasterId = @ItemMasterId)
-			BEGIN 
+					 WHERE StockLineId = @StockLineId AND SalesOrderId = @SalesOrderId AND ItemMasterId = @ItemMasterId AND SalesOrderPartId = @SalesOrderPartId)
+			BEGIN
 				--Get Part Data
 				SELECT @ReservePartQtyReserved = SORP.QtyToReserve,
 					   @ReservePartTotalReserved = SORP.TotalReserved
 					FROM [DBO].[SalesOrderReserveParts] SORP WITH(NOLOCK)
 					WHERE SORP.SalesOrderId = @SalesOrderId AND SORP.ItemMasterId = @ItemMasterId
-					AND SORP.StockLineId = @StockLineId;
+					AND SORP.StockLineId = @StockLineId AND SORP.SalesOrderPartId = @SalesOrderPartId;
 
 				--For Reserve
 				IF(@ReserveStatusId = @PartStatusId)
@@ -470,10 +471,9 @@ BEGIN
 					IF (ISNULL(@ReservedQty, 0) > 0)
 					BEGIN
 						--Get Part Data
-						SELECT @PartQty = SOP.QtyOrder 
+						SELECT @PartQty = SOP.QtyOrder
 							FROM [DBO].[SalesOrderPartV1] SOP WITH(NOLOCK)
-							WHERE SOP.SalesOrderId = @SalesOrderId AND SOP.ItemMasterId = @ItemMasterId
-							AND SOP.ConditionId = @ConditionId;
+							WHERE SOP.SalesOrderId = @SalesOrderId AND SOP.SalesOrderPartId = @SalesOrderPartId;
 
 						--For Reserve
 						IF(@ReserveStatusId = @PartStatusId)

--- a/PAS_DB/dbo/Stored Procedures/Procs1/SearchStockLinePickTicketPop.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/SearchStockLinePickTicketPop.sql
@@ -21,14 +21,16 @@
 	11    20/July/2026			 RAJESH GAMI						[PN-17350] - Removed IsNonStock=0 filters so Non-Stock parts appear on the pick ticket.
 	12    31/July/2026			 MOIN BLOCH	  					    [PN-17513] - Added IsNonStock=1 filters so Non-Stock parts not appear on the pick ticket.
 	12    03/Aug/2026			 MOIN BLOCH	  					    [PN-17542] - Fix For Non-Stock Non-Service data need to come
+	13    05/Aug/2026			 KISHOR MAKWANA					    [PN-17439] - Added @SalesOrderPartId so duplicate part+condition lines (different SequenceNumber) don't collide in the single-line popup
 
 EXEC [dbo].[SearchStockLinePickTicketPop] 103607, 7, 11269, 0
-**************************************************************/ 
-CREATE   PROCEDURE [dbo].[SearchStockLinePickTicketPop]
-	@ItemMasterIdlist bigint, 
+**************************************************************/
+CREATE    PROCEDURE [dbo].[SearchStockLinePickTicketPop]
+	@ItemMasterIdlist bigint,
 	@ConditionId BIGINT,
 	@SalesOrderId bigint,
-	@IsMultiplePickTicket bit = 0
+	@IsMultiplePickTicket bit = 0,
+	@SalesOrderPartId BIGINT = NULL
 AS
 BEGIN
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
@@ -180,13 +182,15 @@ BEGIN
 				LEFT JOIN DBO.LegalEntity leTraceble WITH(NOLOCK) ON sl.TraceableTo = leTraceble.LegalEntityId
 				LEFT JOIN DBO.SOPickTicket Pick WITH(NOLOCK) ON Pick.SalesOrderPartId = sop.SalesOrderPartId and stk.SalesOrderStocklineId = pick.SalesOrderPartStocklineId
 				LEFT JOIN (SELECT ItemMasterId, [Name],StockLineId FROM DBO.Stockline S WITH(NOLOCK) INNER JOIN DBO.Manufacturer M WITH(NOLOCK) ON M.ManufacturerId = S.ManufacturerId) Smf ON Smf.ItemMasterId = im.ItemMasterId AND Smf.StockLineId = sl.StockLineId
-				WHERE 				    
+				WHERE
 					(ISNULL(im.[IsService],0) <> 1 OR ISNULL(im.[IsNonStock],0) <> 1) AND
-					im.ItemMasterId = @ItemMasterIdlist AND 
-					so.SalesOrderId = @SalesOrderId AND 
-					((sor.QtyToReserve + (SELECT ISNULL(SUM(ship_item.QtyShipped), 0) FROM DBO.SalesOrderShipping ship WITH(NOLOCK) 
+					im.ItemMasterId = @ItemMasterIdlist AND
+					sop.ConditionId = @ConditionId AND
+					(@SalesOrderPartId IS NULL OR sop.SalesOrderPartId = @SalesOrderPartId) AND
+					so.SalesOrderId = @SalesOrderId AND
+					((sor.QtyToReserve + (SELECT ISNULL(SUM(ship_item.QtyShipped), 0) FROM DBO.SalesOrderShipping ship WITH(NOLOCK)
 						INNER JOIN SalesOrderShippingItem ship_item WITH(NOLOCK) on ship_item.SalesOrderShippingId = ship.SalesOrderShippingId AND ship.SalesOrderId = @SalesOrderId and ship_item.SalesOrderPartId = sop.SalesOrderPartId
-						INNER JOIN SOPickTicket sopi with(nolock) on ship_item.SOPickTicketId = sopi.SOPickTicketId and sopi.SOPickTicketId = Pick.SOPickTicketId)) - 
+						INNER JOIN SOPickTicket sopi with(nolock) on ship_item.SOPickTicketId = sopi.SOPickTicketId and sopi.SOPickTicketId = Pick.SOPickTicketId)) -
 					(SELECT ISNULL(SUM(QtyToShip), 0) FROM SOPickTicket s WITH(NOLOCK) Where s.SalesOrderId = @SalesOrderId AND s.SalesOrderPartStocklineId = stk.SalesOrderStocklineId)
 					) > 0
 					 END

--- a/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetPickTicketApproveList.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetPickTicketApproveList.sql
@@ -24,12 +24,13 @@
 	7    08/07/2025   Vishal Suthar		Added a check for approval of the part before generating pick ticket
 	8    26/12/2025   Amit Ghediya		Update condition for ReadyToPick
 	9    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
-	10    09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
-	11    20/July/2026			 RAJESH GAMI						[PN-17350] - Removed IsNonStock=0 filters so Non-Stock parts appear on the pick ticket.
-     
+	10   09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
+	11   20/July/2026			 RAJESH GAMI						[PN-17350] - Removed IsNonStock=0 filters so Non-Stock parts appear on the pick ticket.
+	12   05/Aug/2026			 Kishor Makwana						[PN-17439] - Fixed SalesOrderPartId (was hardcoded to 0) and scoped the per-line Qty/QtyToShip/ReadyToPick/TotalReadyToPick subqueries to SalesOrderPartId instead of ItemMasterId+ConditionId, so duplicate Part+Condition lines (different SequenceNumber) no longer merge into a single Pick Ticket summary row.
+	
 -- EXEC [dbo].[sp_GetPickTicketApproveList] 851
 **************************************************************/
-CREATE   PROCEDURE [dbo].[sp_GetPickTicketApproveList]
+CREATE     PROCEDURE [dbo].[sp_GetPickTicketApproveList]
 	@SalesOrderId  bigint
 AS
 BEGIN
@@ -39,9 +40,9 @@ BEGIN
 	BEGIN TRY
 	BEGIN TRANSACTION
 	BEGIN
-		;WITH CTE AS (select DISTINCT 0 AS SalesOrderPartId, sop.ItemMasterId, sop.SalesOrderId,imt.PartNumber,imt.PartDescription,
-		(SELECT TOP 1 QtyRequested FROM DBO.SalesOrderPartV1 WITH(NOLOCK) 
-			Where SalesOrderId = @SalesOrderId AND ItemMasterId = sop.ItemMasterId AND ConditionId = sop.ConditionId) AS Qty,
+		;WITH CTE AS (select DISTINCT sop.SalesOrderPartId AS SalesOrderPartId, sop.ItemMasterId, sop.SalesOrderId,CAST(sop.SequenceNumber as VARCHAR(10))+' - '+imt.PartNumber as PartNumber,imt.PartDescription,
+		(SELECT TOP 1 QtyRequested FROM DBO.SalesOrderPartV1 WITH(NOLOCK)
+			Where SalesOrderId = @SalesOrderId AND SalesOrderPartId = sop.SalesOrderPartId) AS Qty,
 		'' AS SerialNumber, 
 		(SELECT SUM(QuantityAvailable) FROM DBO.StockLine sll WITH(NOLOCK) 
 		Where sll.ItemMasterId = sop.ItemMasterId AND sll.ConditionId = sop.ConditionId) AS QuantityAvailable,
@@ -49,8 +50,8 @@ BEGIN
 		(SELECT SUM(SP.QtyToShip) FROM DBO.SOPickTicket SP WITH(NOLOCK)
 		INNER JOIN DBO.SalesOrder S_O WITH(NOLOCK) ON S_O.SalesOrderId = SP.SalesOrderId
 		INNER JOIN DBO.SalesOrderPartV1 SO_P WITH(NOLOCK) ON SP.SalesOrderPartId = SO_P.SalesOrderPartId
-		Where SP.SalesOrderId = @SalesOrderId AND ItemMasterId = sop.ItemMasterId AND ConditionId = sop.ConditionId) AS QtyToShip,
-		((SELECT TOP 1 QtyRequested FROM DBO.SalesOrderPartV1 WITH(NOLOCK) Where SalesOrderId = @SalesOrderId AND ItemMasterId = sop.ItemMasterId AND ConditionId = sop.ConditionId) - SUM(ISNULL(sopt.QtyToShip,0))) as QtyToPick,
+		Where SP.SalesOrderId = @SalesOrderId AND SP.SalesOrderPartId = sop.SalesOrderPartId) AS QtyToShip,
+		((SELECT TOP 1 QtyRequested FROM DBO.SalesOrderPartV1 WITH(NOLOCK) Where SalesOrderId = @SalesOrderId AND SalesOrderPartId = sop.SalesOrderPartId) - SUM(ISNULL(sopt.QtyToShip,0))) as QtyToPick,
 		'' as [Status], 
 		sop.ConditionId, 
 		(SELECT ((ISNULL(SUM(agg.QtyReserved), 0) 
@@ -63,7 +64,7 @@ BEGIN
 			SELECT sopp.SalesOrderPartId, SUM(sos.QtyReserved) AS QtyReserved
 			FROM DBO.SalesOrderPartV1 sopp WITH(NOLOCK) 
 			INNER JOIN DBO.SalesOrderStocklineV1 sos WITH(NOLOCK) ON sos.SalesOrderPartId = sopp.SalesOrderPartId
-			WHERE sopp.SalesOrderId = @SalesOrderId AND sopp.ItemMasterId = sop.ItemMasterId AND sopp.ConditionId = sop.ConditionId
+			WHERE sopp.SalesOrderId = @SalesOrderId AND sopp.SalesOrderPartId = sop.SalesOrderPartId
 			GROUP BY sopp.SalesOrderPartId
 		) agg
 		LEFT JOIN 
@@ -91,7 +92,7 @@ BEGIN
 				SELECT sopp.SalesOrderPartId, SUM(sos.QtyReserved) AS QtyReserved
 				FROM DBO.SalesOrderPartV1 sopp WITH(NOLOCK)
 				LEFT JOIN DBO.SalesOrderStocklineV1 sos WITH(NOLOCK) ON sos.SalesOrderPartId = sopp.SalesOrderPartId
-				WHERE sopp.SalesOrderId = @SalesOrderId AND sopp.ItemMasterId = sop.ItemMasterId AND sopp.ConditionId = sop.ConditionId
+				WHERE sopp.SalesOrderId = @SalesOrderId AND sopp.SalesOrderPartId = sop.SalesOrderPartId
 				GROUP BY sopp.SalesOrderPartId
 			) agg
 			LEFT JOIN 
@@ -117,7 +118,7 @@ BEGIN
 		LEFT JOIN DBO.StockLine sl WITH(NOLOCK) on sl.StockLineId = stk.StockLineId
 		LEFT JOIN DBO.SalesOrder so WITH(NOLOCK) on so.SalesOrderId = sop.SalesOrderId
 		LEFT JOIN DBO.SalesOrderQuote soq WITH(NOLOCK) on soq.SalesOrderQuoteId = so.SalesOrderQuoteId
-		LEFT JOIN DBO.SOPickTicket sopt WITH(NOLOCK) on sopt.SalesOrderId = sop.SalesOrderId
+		LEFT JOIN DBO.SOPickTicket sopt WITH(NOLOCK) on sopt.SalesOrderId = sop.SalesOrderId AND sopt.SalesOrderPartId = sop.SalesOrderPartId
 		LEFT JOIN DBO.Customer cr WITH(NOLOCK) on cr.CustomerId = so.CustomerId
 		where sop.SalesOrderId=@SalesOrderId AND ((sopt.SOPickTicketId IS NULL AND sop.QtyReserved > 0) OR sopt.SOPickTicketId IS NOT NULL)
 		AND EXISTS (
@@ -130,7 +131,7 @@ BEGIN
          group by sop.SalesOrderId,imt.PartNumber,imt.PartDescription,
 		so.SalesOrderNumber,soq.SalesOrderQuoteNumber,sop.ItemMasterId,
 		sl.ConditionId, cr.[Name],cr.CustomerCode, sop.ConditionId
-		,sl.isSerialized, imt.ItemMasterId)
+		,sl.isSerialized, imt.ItemMasterId, sop.SalesOrderPartId,sop.SequenceNumber)
 
 		SELECT DISTINCT cte.SalesOrderPartId, CTE.ItemMasterId, cte.SalesOrderId, PartNumber, PartDescription, cte.Qty,
 		SerialNumber, QuantityAvailable,
@@ -141,7 +142,6 @@ BEGIN
 		cte.[Status], CustomerName, CustomerCode 
 		,CASE WHEN SUM(cte.TotalReadyToPick) < 0 THEN 0 ELSE SUM(cte.TotalReadyToPick) END AS TotalReadyToPick 
 		FROM CTE
-		LEFT JOIN SOPickTicket sopt WITH(NOLOCK) ON sopt.SalesOrderId = cte.SalesOrderId AND sopt.SalesOrderPartId = cte.SalesOrderPartId
 		GROUP BY cte.SalesOrderPartId, CTE.ItemMasterId, cte.SalesOrderId, PartNumber, PartDescription, cte.Qty,
 		SerialNumber, QuantityAvailable, cte.[Status], SalesOrderNumber, SalesOrderQuoteNumber, ConditionId, CustomerName, CustomerCode--,cte.TotalReadyToPick 
 	END

--- a/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetPickTicketChildList.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetPickTicketChildList.sql
@@ -26,7 +26,8 @@ CREATE   PROCEDURE [dbo].[sp_GetPickTicketChildList]
 	@SalesOrderId  bigint,
 	@ItemMasterId bigint,
 	@ConditionId bigint,
-	@EmployeeId bigint
+	@EmployeeId bigint,
+	@SalesOrderPartId BIGINT
 AS
 BEGIN
 	SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
@@ -70,7 +71,7 @@ BEGIN
 		LEFT JOIN DBO.StockLine sl WITH(NOLOCK) on sl.StockLineId = stk.StockLineId
 		INNER JOIN DBO.Employee emp WITH(NOLOCK) on emp.EmployeeId = sopt.PickedById
 		LEFT JOIN DBO.Employee empy WITH(NOLOCK) on empy.EmployeeId = sopt.ConfirmedById
-		WHERE sopt.SalesOrderId = @SalesOrderId AND sop.ItemMasterId = @ItemMasterId and sop.ConditionId = @ConditionId
+		WHERE sopt.SalesOrderId = @SalesOrderId AND sop.ItemMasterId = @ItemMasterId and sop.ConditionId = @ConditionId AND sop.SalesOrderPartId =@SalesOrderPartId
 	
 	END
 	COMMIT  TRANSACTION

--- a/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetSOShippingChildList.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetSOShippingChildList.sql
@@ -26,9 +26,10 @@
 	8	25 APR 2026     RAJESH GAMI         Added MastercompanyId in the condition 
 	9	09/July/2026 RAJESH GAMI     [PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	10	20/July/2026 RAJESH GAMI     [PN-17350] - Removed IsNonStock=0 filter so Non-Stock stockline fields populate correctly on the shipping list.
- EXEC [dbo].[sp_GetSOShippingChildList] 1272, 318, 7  
+	11	05/Aug/2026 Kishor Makwana   [PN-17439] - Fixed @SalesOrderPartId filter to match the real SalesOrderPartV1 PK (sop.SalesOrderPartId) instead of ItemMasterId, and stopped hardcoding ItemNo to 0, so duplicate Part+Condition lines (different SequenceNumber) no longer show each other's shipping/pick ticket rows.
+ EXEC [dbo].[sp_GetSOShippingChildList] 1272, 318, 7
 **************************************************************/
-CREATE   PROCEDURE [dbo].[sp_GetSOShippingChildList]  
+CREATE    PROCEDURE [dbo].[sp_GetSOShippingChildList]  
  @SalesOrderId  bigint,  
  @SalesOrderPartId bigint,  
  @ConditionId bigint  
@@ -45,7 +46,7 @@ BEGIN
 	  SELECT DISTINCT sopt.SOPickTicketId, sos.SalesOrderShippingId, CASE WHEN sosi.SalesOrderPartId IS NOT NULL THEN sos.ShipDate ELSE NULL END AS ShipDate,  
 			 CASE WHEN sosi.SalesOrderPartId IS NOT NULL THEN sos.SOShippingNum ELSE NULL END AS SOShippingNum,  
 			 sopt.SOPickTicketNumber, sopt.QtyToShip, so.SalesOrderNumber, imt.partnumber, imt.PartDescription, sl.StockLineNumber,  
-			 sl.SerialNumber, cr.[Name] as CustomerName, soc.CustomsValue, soc.CommodityCode, ISNULL(sosi.QtyShipped,0) as QtyShipped, 0 AS ItemNo,-- sop.ItemNo,  
+			 sl.SerialNumber, cr.[Name] as CustomerName, soc.CustomsValue, soc.CommodityCode, ISNULL(sosi.QtyShipped,0) as QtyShipped, sop.SequenceNumber AS ItemNo,
 			 sos.SalesOrderId, (CASE WHEN sosi.SalesOrderPartId IS NOT NULL THEN sosi.SalesOrderPartId ELSE sop.SalesOrderPartId END) SalesOrderPartId,  
 			 sos.AirwayBill, SPB.PackagingSlipNo, SPB.PackagingSlipId,   
 			 CASE WHEN sos.SalesOrderShippingId IS NOT NULL THEN sos.SmentNum ELSE 0 END AS 'SmentNo',  
@@ -82,9 +83,9 @@ BEGIN
 		WHERE SOBI.ShippingId = sosi.SalesOrderShippingId AND ISNULL(SOBI.IsPerformaInvoice,0) = 0 AND SOBI.ModuleId = @soModuleId AND ISNULL(SOBI.IsVersionIncrease,0) = 0 AND BI.ModuleId = @soModuleId AND ISNULL(BI.IsVersionIncrease,0) = 0
 		ORDER BY BI.BillingInvoicingId DESC
 	  ) InvoiceData
-	  WHERE sopt.SalesOrderId = @SalesOrderId  
-	  AND sop.ItemMasterId = @SalesOrderPartId  
-	  AND sop.ConditionId = @ConditionId  
+	  WHERE sopt.SalesOrderId = @SalesOrderId
+	  AND sop.SalesOrderPartId = @SalesOrderPartId
+	  AND sop.ConditionId = @ConditionId
 	  AND ISNULL(sopt.IsConfirmed,0) = 1  AND sopt.MasterCompanyId = @masterCompanyId
  END  
  COMMIT  TRANSACTION  

--- a/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetSOShippingParentList.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs1/sp_GetSOShippingParentList.sql
@@ -21,10 +21,11 @@
 	2    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	3    09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	4    20/July/2026			 RAJESH GAMI						[PN-17350] - Removed IsNonStock=0 filter so Non-Stock ItemMaster/Stockline fields populate correctly on the shipping list.
-     
+	5    05/Aug/2026			 Kishor Makwana						[PN-17439] - Stopped hardcoding ItemNo to 0 (now uses sop.SequenceNumber) so duplicate Part+Condition lines are distinguishable on the shipping list, matching the real per-line SalesOrderPartId (SOPartId) that this SP already groups by.
+
  -- [dbo].[sp_GetSOShippingParentList] 1269
 **************************************************************/
-CREATE   PROCEDURE [dbo].[sp_GetSOShippingParentList]
+CREATE    PROCEDURE [dbo].[sp_GetSOShippingParentList]
 @SalesOrderId  bigint
 AS
 BEGIN
@@ -34,7 +35,7 @@ BEGIN
 	BEGIN TRY
 	BEGIN TRANSACTION
 	BEGIN
-		SELECT DISTINCT imt.ItemMasterId AS SalesOrderPartId,sop.SalesOrderPartId AS SOPartId, sop.ConditionId, 0 AS ItemNo, so.SalesOrderNumber, imt.partnumber, imt.PartDescription, 
+		SELECT DISTINCT imt.ItemMasterId AS SalesOrderPartId,sop.SalesOrderPartId AS SOPartId, sop.ConditionId, sop.SequenceNumber AS ItemNo, so.SalesOrderNumber, imt.partnumber, imt.PartDescription,
 		SUM(ISNULL(sopt.QtyToShip, 0)) AS QtyToShip,
 		SUM(ISNULL(sosi.QtyShipped, 0)) AS QtyShipped,
 		sop.SalesOrderId,
@@ -52,7 +53,7 @@ BEGIN
 		LEFT JOIN DBO.SalesOrderShipping sos WITH (NOLOCK) ON sos.SalesOrderShippingId = sosi.SalesOrderShippingId 
 					AND sos.SalesOrderId = sopt.SalesOrderId AND sos.SalesOrderId = @SalesOrderId
 		WHERE sop.SalesOrderId = @SalesOrderId AND sopt.IsConfirmed = 1
-		GROUP BY so.SalesOrderNumber, imt.partnumber, imt.PartDescription, imt.ItemMasterId,sop.SalesOrderPartId, sop.SalesOrderId, sop.ConditionId
+		GROUP BY so.SalesOrderNumber, imt.partnumber, imt.PartDescription, imt.ItemMasterId,sop.SalesOrderPartId, sop.SalesOrderId, sop.ConditionId, sop.SequenceNumber
 	END
 	COMMIT  TRANSACTION
 

--- a/PAS_DB/dbo/Stored Procedures/Procs2/USP_AddUpdateSalesOrderPart.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs2/USP_AddUpdateSalesOrderPart.sql
@@ -24,6 +24,7 @@
 	9    20/July/2026	  RAJESH GAMI		[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filters that excluded Non-Stock Stockline when creating a SO part stockline.
 	10   30/July/2026	  MOIN BLOCH        [PN-17485] - Added [IsService],[IsNonStock] Conditions If IsNonStock then Create StockLine
 	11   01/July/2026	  MOIN BLOCH        [PN-17485] - Update QtyOnhand And Qty Reserved in Stockline on update Part Qty
+	12   05/Aug/2026	  KISHOR MAKWANA    [PN-17439] - Added SequenceNumber to persist user-editable Item No on Sales Order parts
 declare @p1 dbo.SOPartListType
 insert into @p1 values(497,1269,216,12,2,178289,NULL,1,5,2,NULL,NULL,3,1,1200,0,0,1200,0,670,330.00,NULL,NULL,NULL,600.00,0,0,1200,335,44.17,0,NULL,N'',NULL,1,N'Jim Roberts')
 insert into @p1 values(501,1269,264,2,2,NULL,NULL,1,3,0,NULL,NULL,3,1,0,0,0,0,0,0,0,NULL,NULL,NULL,300.00,0,0,900,0,100.00,0,NULL,N'',NULL,1,N'Jim Roberts')
@@ -31,7 +32,7 @@ insert into @p1 values(501,1269,264,2,2,NULL,NULL,1,3,0,NULL,NULL,3,1,0,0,0,0,0,
 exec USP_AddUpdateSalesOrderPart @tbl_SalesOrderPartList=@p1
 
 **************************************************************/
-CREATE   PROCEDURE [dbo].[USP_AddUpdateSalesOrderPart]
+CREATE    PROCEDURE [dbo].[USP_AddUpdateSalesOrderPart]
 	@tbl_SalesOrderPartList SOPartListType READONLY
 AS
 BEGIN
@@ -91,19 +92,20 @@ BEGIN
 		Weight decimal(18,4),
 		SizeLength decimal(18,4),
 		SizeWidth decimal(18,4),
-		SizeHeight decimal(18,4)
+		SizeHeight decimal(18,4),
+		SequenceNumber BIGINT
 	)
 
 	INSERT INTO #SOPartDetails (SalesOrderPartId,SalesOrderId,ItemMasterId,ConditionId,PriorityId,StocklineId,SalesOrderStocklineId,StatusId,
 	QtyRequested,QtyOrder,QtyAvailable,QtyOH,CurrencyId,FxRate,GrossSaleAmount,DiscountAmount,NetSaleAmount,TaxAmount,UnitCostExtended,MarginAmount,
 	CustomerRequestDate,PromisedDate,EstimatedShipDate,UnitSalesPrice,MarkUpPercentage,DiscountPercentage,MarkUpAmount,SalesPriceExtended,UnitCost,
 	MarginPercentage,TaxPercentage,StatusName,AltOrEqType,Notes,MasterCompanyId,CreatedBy,
-	ECCN,HSCODE,[Weight],SizeLength,SizeWidth,SizeHeight)
+	ECCN,HSCODE,[Weight],SizeLength,SizeWidth,SizeHeight,SequenceNumber)
 	SELECT SalesOrderPartId,SalesOrderId,ItemMasterId,ConditionId,PriorityId,StocklineId,SalesOrderStocklineId,StatusId,
 	QtyRequested,QtyOrder,QtyAvailable,QtyOH,CurrencyId,FxRate,GrossSaleAmount,DiscountAmount,NetSaleAmount,TaxAmount,UnitCostExtended,MarginAmount,
 	CustomerRequestDate,PromisedDate,EstimatedShipDate,UnitSalesPrice,MarkUpPercentage,DiscountPercentage,MarkUpAmount,SalesPriceExtended,UnitCost,
 	MarginPercentage,TaxPercentage,StatusName,AltOrEqType,Notes,MasterCompanyId,CreatedBy,
-	ECCN,HSCODE,[Weight],SizeLength,SizeWidth,SizeHeight
+	ECCN,HSCODE,[Weight],SizeLength,SizeWidth,SizeHeight,SequenceNumber
 	FROM @tbl_SalesOrderPartList;
 
 	SELECT @SOPartLoopID = MAX(ID) FROM #SOPartDetails;
@@ -140,21 +142,23 @@ BEGIN
 		DECLARE @SizeLength AS decimal(18,4);
 		DECLARE @SizeWidth AS decimal(18,4);
 		DECLARE @SizeHeight AS decimal(18,4);
+		DECLARE @SequenceNumber AS BIGINT;
 		DECLARE @PriorityId BIGINT = 0, @StocklineCount int = 0;
 
 		SELECT @SalesOrderPartId = SalesOrderPartId, @SalesOrderId = SalesOrderId, @ItemMasterId = ItemMasterId, @ConditionId = ConditionId, @StocklineId = StocklineId,
 		@SalesOrderStocklineId = SalesOrderStocklineId, @MasterCompanyId = MasterCompanyId, @UnitSalesPrice = UnitSalesPrice, @MarkUpAmount = MarkUpAmount, @DiscountAmount = DiscountAmount, @QtyOrder = QtyOrder,
 		@CreatedBy = CreatedBy, @MarkUpPercentage = MarkUpPercentage, @UnitCost = UnitCost, @MarginAmount = MarginAmount, @MarginPercentage = MarginPercentage,
-		@DiscountPercentage = DiscountPercentage, @QtyRequested = QtyRequested, @Notes = Notes, 
+		@DiscountPercentage = DiscountPercentage, @QtyRequested = QtyRequested, @Notes = Notes,
 		@CustomerRequestDate = CustomerRequestDate, @PromisedDate = PromisedDate, @EstimatedShipDate = EstimatedShipDate,@SOPartStatus = StatusId,
-		@ECCN = ECCN,@HSCODE = HSCODE, @Weight = [Weight], @SizeLength = SizeLength, @SizeWidth = SizeWidth, @SizeHeight = SizeHeight,@PriorityId = PriorityId
+		@ECCN = ECCN,@HSCODE = HSCODE, @Weight = [Weight], @SizeLength = SizeLength, @SizeWidth = SizeWidth, @SizeHeight = SizeHeight,@PriorityId = PriorityId,
+		@SequenceNumber = SequenceNumber
 		FROM #SOPartDetails WHERE ID = @SOMInID;
 		
 		IF (ISNULL(@SalesOrderPartId, 0) = 0) -- Add New Part
 		BEGIN
 			SELECT @SOPartStatus = SOPartStatusId FROM [DBO].[SOPartStatus] WITH (NOLOCK) WHERE [PartStatus] = 'Open';
 
-			IF NOT EXISTS (SELECT * FROM [dbo].[SalesOrderPartV1] WITH (NOLOCK) WHERE SalesOrderId = @SalesOrderId AND ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId)
+			IF NOT EXISTS (SELECT * FROM [dbo].[SalesOrderPartV1] WITH (NOLOCK) WHERE SalesOrderId = @SalesOrderId AND ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId AND ISNULL(SequenceNumber,0) = ISNULL(@SequenceNumber,0))
 			BEGIN
 				DECLARE @CurrencyCode VARCHAR(10) = '';
 				DECLARE @CurrencyId BIGINT = 0,@IsService BIT = 0,@IsNonStock BIT = 0								 
@@ -164,8 +168,8 @@ BEGIN
 				LEFT JOIN [DBO].[SalesOrder] SO WITH (NOLOCK) ON SO.CustomerId = CF.CustomerId
 				WHERE SO.SalesOrderId = @SalesOrderId;
 
-				INSERT INTO [dbo].[SalesOrderPartV1] ([SalesOrderId],[ItemMasterId],[ConditionId],[QtyRequested],[QtyOrder],[QtyReserved],[CurrencyId],[FxRate],[PriorityId],[StatusId],[CustomerRequestDate],[PromisedDate],[EstimatedShipDate],[Notes],[MasterCompanyId],[CreatedBy],[CreatedDate],[UpdatedBy],[UpdatedDate],[IsActive],[IsDeleted],[ECCN],[HSCODE],[Weight],[SizeLength],[SizeWidth],[SizeHeight],[AltOrEqType],UnitSalesPrice)
-				SELECT SalesOrderId, ItemMasterId, ConditionId, QtyRequested, QtyOrder, 0, CurrencyId, FxRate, PriorityId, @SOPartStatus, CustomerRequestDate, PromisedDate, EstimatedShipDate, Notes, MasterCompanyId, CreatedBy, GETUTCDATE(), CreatedBy, GETUTCDATE(), 1, 0,ECCN,HSCODE,[Weight],SizeLength,SizeWidth,SizeHeight,[AltOrEqType],UnitSalesPrice
+				INSERT INTO [dbo].[SalesOrderPartV1] ([SalesOrderId],[ItemMasterId],[ConditionId],[QtyRequested],[QtyOrder],[QtyReserved],[CurrencyId],[FxRate],[PriorityId],[StatusId],[CustomerRequestDate],[PromisedDate],[EstimatedShipDate],[Notes],[MasterCompanyId],[CreatedBy],[CreatedDate],[UpdatedBy],[UpdatedDate],[IsActive],[IsDeleted],[ECCN],[HSCODE],[Weight],[SizeLength],[SizeWidth],[SizeHeight],[AltOrEqType],UnitSalesPrice,SequenceNumber)
+				SELECT SalesOrderId, ItemMasterId, ConditionId, QtyRequested, QtyOrder, 0, CurrencyId, FxRate, PriorityId, @SOPartStatus, CustomerRequestDate, PromisedDate, EstimatedShipDate, Notes, MasterCompanyId, CreatedBy, GETUTCDATE(), CreatedBy, GETUTCDATE(), 1, 0,ECCN,HSCODE,[Weight],SizeLength,SizeWidth,SizeHeight,[AltOrEqType],UnitSalesPrice,SequenceNumber
 				FROM #SOPartDetails WHERE ID = @SOMInID;
 
 				SET @SalesOrderPartId = SCOPE_IDENTITY();
@@ -207,7 +211,7 @@ BEGIN
 			END
 			ELSE
 			BEGIN
-				SELECT @SalesOrderPartId = SalesOrderPartId FROM [dbo].[SalesOrderPartV1] WITH (NOLOCK) WHERE ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId AND SalesOrderId = @SalesOrderId;
+				SELECT @SalesOrderPartId = SalesOrderPartId FROM [dbo].[SalesOrderPartV1] WITH (NOLOCK) WHERE ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId AND SalesOrderId = @SalesOrderId AND ISNULL(SequenceNumber,0) = ISNULL(@SequenceNumber,0);
 			END
 
 			IF (@StockLineId IS NOT NULL AND @StockLineId > 0) -- Added at Stockline Level
@@ -247,7 +251,7 @@ BEGIN
 			DECLARE @IsQtyRequestedModified BIT,@IsPriorityModified BIT,@IsUnitSalesModified BIT;
 			DECLARE @ExistingQtyReq INT,@ExistingPriority INT,@ExistingUnitSales DECIMAL;
 
-			SELECT @ExistingQtyReq = SOP.QtyRequested,@ExistingPriority = PriorityId  FROM [DBO].[SalesOrderPartV1] SOP WITH (NOLOCK) WHERE SOP.SalesOrderPartId = @SalesOrderPartId;
+			SELECT @ExistingQtyReq = SOP.QtyRequested,@ExistingPriority = PriorityId  FROM [DBO].[SalesOrderPartV1] SOP WITH (NOLOCK) WHERE SOP.SalesOrderPartId = @SalesOrderPartId  AND SOP.SequenceNumber = @SequenceNumber;
 			IF(@SalesOrderStocklineId > 0)
 			BEGIN
 				 SELECT @ExistingUnitSales = SOPC.UnitSalesPrice  FROM [DBO].[SalesOrderStockLineCost] SOPC WITH (NOLOCK) WHERE SOPC.SalesOrderStocklineId = @SalesOrderStocklineId;
@@ -271,7 +275,8 @@ BEGIN
 			SizeWidth = @SizeWidth,
 			SizeHeight = @SizeHeight,
 			PriorityId = @PriorityId,
-			UnitSalesPrice = (CASE WHEN @StocklineCount > 0 THEN UnitSalesPrice ELSE @UnitSalesPrice END)
+			UnitSalesPrice = (CASE WHEN @StocklineCount > 0 THEN UnitSalesPrice ELSE @UnitSalesPrice END),
+			SequenceNumber = @SequenceNumber
 			WHERE SalesOrderPartId = @SalesOrderPartId;
 
 			UPDATE [DBO].[SalesOrderPartV1]
@@ -361,18 +366,18 @@ BEGIN
 				SOP.QtyOrder = QS.TotalQtyQuoted
 			FROM [DBO].[SalesOrderPartV1] SOP
 				INNER JOIN QuotedSums QS ON SOP.SalesOrderPartId = QS.SalesOrderPartId
-			WHERE SOP.SalesOrderPartId = @SalesOrderPartId;
+			WHERE SOP.SalesOrderPartId = @SalesOrderPartId  AND SOP.SequenceNumber =@SequenceNumber;
 
 
-			IF EXISTS(SELECT * FROM #SOPartDetails WHERE  SalesOrderPartId = @SalesOrderPartId)
+			IF EXISTS(SELECT * FROM #SOPartDetails WHERE  SalesOrderPartId = @SalesOrderPartId  AND SequenceNumber = @SequenceNumber)
 			BEGIN
 				;WITH QuotedSumsNoStockline AS (
-					SELECT SOP.SalesOrderPartId, SUM(ISNULL(SOS.QtyOrder, 0)) AS TotalQtyQuoted
+					SELECT SOP.SalesOrderPartId, SUM(ISNULL(SOS.QtyOrder, 0)) AS TotalQtyQuoted ,SOP.SequenceNumber
 					FROM [DBO].[SalesOrderPartV1] SOP WITH (NOLOCK)
-						INNER JOIN #SOPartDetails AS SPD  WITH (NOLOCK) ON  SPD.SalesOrderPartId = SOP.SalesOrderPartId
+						INNER JOIN #SOPartDetails AS SPD  WITH (NOLOCK) ON  SPD.SalesOrderPartId = SOP.SalesOrderPartId  and SPD.SequenceNumber= SOP.SequenceNumber
 						LEFT JOIN [DBO].[SalesOrderStocklineV1] SOS WITH (NOLOCK) ON SOP.SalesOrderPartId = SOS.SalesOrderPartId
 					WHERE SOS.SalesOrderPartId IS NULL
-					GROUP BY SOP.SalesOrderPartId
+					GROUP BY SOP.SalesOrderPartId ,SOP.SequenceNumber
 				)
 
 				UPDATE SOP
@@ -380,7 +385,7 @@ BEGIN
 					SOP.QtyOrder = CASE WHEN QS.TotalQtyQuoted > 0 THEN QS.TotalQtyQuoted ELSE SOP.QtyOrder END
 				FROM [DBO].[SalesOrderPartV1] SOP
 					INNER JOIN QuotedSumsNoStockline QS ON SOP.SalesOrderPartId = QS.SalesOrderPartId
-				WHERE SOP.SalesOrderPartId = @SalesOrderPartId;
+				WHERE SOP.SalesOrderPartId = @SalesOrderPartId  AND SOP.SequenceNumber = @SequenceNumber;
 			END
 
 			IF NOT EXISTS (SELECT TOP 1 1 FROM [DBO].[SalesOrderStocklineV1] SOS WITH (NOLOCK) WHERE SOS.SalesOrderPartId = @SalesOrderPartId)
@@ -388,7 +393,7 @@ BEGIN
 				UPDATE SOP
 				SET SOP.QtyOrder = CASE WHEN @IsQtyRequestedModified = 1 THEN @QtyRequested ELSE @QtyOrder END
 				FROM [DBO].[SalesOrderPartV1] SOP
-				WHERE SOP.SalesOrderPartId = @SalesOrderPartId;
+				WHERE SOP.SalesOrderPartId = @SalesOrderPartId AND SOP.SequenceNumber= @SequenceNumber;;
 			END
 			
 			-- Update Stock Line For Non-Stock On Update

--- a/PAS_DB/dbo/Stored Procedures/Procs2/USP_AddUpdateSalesOrderQuotePart.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs2/USP_AddUpdateSalesOrderQuotePart.sql
@@ -19,6 +19,7 @@
 	7    20-11-2025	  Rajesh Gami		Added UnitSalesPrice in SalesOrderQuotePartV1 table
 	8    09/July/2026	  RAJESH GAMI		[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	9    20/July/2026	  RAJESH GAMI		[PN-17350] - Allow Non-Stock Inventory Parts in Sales Order Quote and Sales Order: removed IsNonStock=0 filters that excluded Non-Stock Stockline when creating a SOQ part stockline.
+	10   05/Aug/2026	  KISHOR MAKWANA    [PN-17439] - Added SequenceNumber to persist user-editable Item No on Sales Order parts
 declare @p1 dbo.SOQPartListType
 insert into @p1 values(909,871,318,7,3,NULL,3,NULL,1,3,3,NULL,NULL,1,1.000000,378.2,5,6.12,348.84,0,0,348.84,'2024-11-06 00:00:00','2024-11-07 00:00:00',NULL,120.00,2,2.4,360.00,0,100,0,NULL,N'',NULL,1,N'admin')
 insert into @p1 values(910,871,20753,9,3,NULL,3,NULL,1,3,3,NULL,NULL,NULL,1.000000,6.0,5,105.57,0,0,0,0,NULL,NULL,'2024-11-05 00:00:00',230.00,2,2.0,105.57,0,0,0,NULL,N'',NULL,1,N'admin')
@@ -26,7 +27,7 @@ insert into @p1 values(910,871,20753,9,3,NULL,3,NULL,1,3,3,NULL,NULL,NULL,1.0000
 exec USP_AddUpdateSalesOrderQuotePart @tbl_SalesOrderQuotePartList=@p1
 
 ***************************************************************/
-CREATE   PROCEDURE [dbo].[USP_AddUpdateSalesOrderQuotePart]
+CREATE    PROCEDURE [dbo].[USP_AddUpdateSalesOrderQuotePart]
 	@tbl_SalesOrderQuotePartList SOQPartListType READONLY
 	--@tbl_SalesOrderQuoteStocklineList SOQStockLineListType READONLY
 AS
@@ -85,17 +86,18 @@ BEGIN
 		CreatedBy varchar(100),
 		IsNoQuote BIT NULL,
 		IsLotAssigned BIT NULL,
-		LotId BIGINT NULL
+		LotId BIGINT NULL,
+		SequenceNumber BIGINT NULL
 	)
 
 	INSERT INTO #SOQPartDetails (SalesOrderQuotePartId,SalesOrderQuoteId,ItemMasterId,ConditionId,PriorityId,StocklineId,QuantityQuote,SalesOrderQuoteStocklineId,StatusId,
 	QtyRequested,QtyQuoted,QtyAvailable,QtyOH,CurrencyId,FxRate,GrossSaleAmount,DiscountAmount,NetSaleAmount,TaxAmount,UnitCostExtended,MarginAmount,
 	CustomerRequestDate,PromisedDate,EstimatedShipDate,UnitSalesPrice,MarkUpPercentage,DiscountPercentage,MarkUpAmount,SalesPriceExtended,UnitCost,
-	MarginPercentage,TaxPercentage,StatusName,AltOrEqType,Notes,MasterCompanyId,CreatedBy,IsNoQuote,IsLotAssigned,LotId)
+	MarginPercentage,TaxPercentage,StatusName,AltOrEqType,Notes,MasterCompanyId,CreatedBy,IsNoQuote,IsLotAssigned,LotId,SequenceNumber)
 	SELECT SalesOrderQuotePartId,SalesOrderQuoteId,ItemMasterId,ConditionId,PriorityId,StocklineId,QuantityQuote,SalesOrderQuoteStocklineId,StatusId,
 	QtyRequested,QtyQuoted,QtyAvailable,QtyOH,CurrencyId,FxRate,GrossSaleAmount,DiscountAmount,NetSaleAmount,TaxAmount,UnitCostExtended,MarginAmount,
 	CustomerRequestDate,PromisedDate,EstimatedShipDate,UnitSalesPrice,MarkUpPercentage,DiscountPercentage,MarkUpAmount,SalesPriceExtended,UnitCost,
-	MarginPercentage,TaxPercentage,StatusName,AltOrEqType,Notes,MasterCompanyId,CreatedBy,IsNoQuote,IsLotAssigned,LotId 
+	MarginPercentage,TaxPercentage,StatusName,AltOrEqType,Notes,MasterCompanyId,CreatedBy,IsNoQuote,IsLotAssigned,LotId,SequenceNumber
 	FROM @tbl_SalesOrderQuotePartList;
 
 	SELECT @SOQPartLoopID = MAX(ID) FROM #SOQPartDetails;
@@ -129,14 +131,15 @@ BEGIN
 		DECLARE @IsNoQuote AS BIT = NULL;
 		DECLARE @IsLotAssigned AS BIT = NULL;
 		DECLARE @LotId AS BIGINT = 0;
+		DECLARE @SequenceNumber AS BIGINT;
 		DECLARE @PriorityId BIGINT = 0,@StocklineCount INT =0;
 
 		SELECT @SalesOrderQuotePartId = SalesOrderQuotePartId, @SalesOrderQuoteId = SalesOrderQuoteId, @ItemMasterId = ItemMasterId, @ConditionId = ConditionId, @StocklineId = StocklineId,
 		@SalesOrderQuoteStocklineId = SalesOrderQuoteStocklineId, @MasterCompanyId = MasterCompanyId, @UnitSalesPrice = UnitSalesPrice, @MarkUpAmount = MarkUpAmount, @DiscountAmount = DiscountAmount, @QtyQuoted = QtyQuoted,
 		@CreatedBy = CreatedBy, @MarkUpPercentage = MarkUpPercentage, @UnitCost = UnitCost, @MarginAmount = MarginAmount, @MarginPercentage = MarginPercentage,
-		@DiscountPercentage = DiscountPercentage, @QtyRequested = QtyRequested, @QuantityToQuote = QuantityQuote, @Notes = Notes, 
+		@DiscountPercentage = DiscountPercentage, @QtyRequested = QtyRequested, @QuantityToQuote = QuantityQuote, @Notes = Notes,
 		@CustomerRequestDate = CustomerRequestDate, @PromisedDate = PromisedDate, @EstimatedShipDate = EstimatedShipDate,@IsNoQuote = IsNoQuote,
-		@IsLotAssigned = IsLotAssigned,@LotId = LotId,@PriorityId = PriorityId
+		@IsLotAssigned = IsLotAssigned,@LotId = LotId,@PriorityId = PriorityId,@SequenceNumber = SequenceNumber
 		FROM #SOQPartDetails WHERE ID = @MinsoqId;
 		
 		IF (ISNULL(@SalesOrderQuotePartId, 0) = 0) -- Add New Part
@@ -144,7 +147,7 @@ BEGIN
 			DECLARE @SOQPartStatus BIGINT;
 			SELECT @SOQPartStatus = SOPartStatusId FROM [DBO].[SOPartStatus] WITH (NOLOCK) WHERE [PartStatus] = 'Open';
 
-			IF NOT EXISTS (SELECT * FROM [dbo].[SalesOrderQuotePartV1] WITH (NOLOCK) WHERE SalesOrderQuoteId = @SalesOrderQuoteId AND ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId)
+			IF NOT EXISTS (SELECT * FROM [dbo].[SalesOrderQuotePartV1] WITH (NOLOCK) WHERE SalesOrderQuoteId = @SalesOrderQuoteId AND ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId AND ISNULL(SequenceNumber,0) = ISNULL(@SequenceNumber,0))
 			BEGIN
 				DECLARE @CurrencyCode VARCHAR(10) = '';
 				DECLARE @CurrencyId BIGINT = 0;
@@ -154,8 +157,8 @@ BEGIN
 				LEFT JOIN [DBO].[SalesOrderQuote] SOQ WITH (NOLOCK) ON SOQ.CustomerId = CF.CustomerId
 				WHERE SOQ.SalesOrderQuoteId = @SalesOrderQuoteId;
 
-				INSERT INTO [dbo].[SalesOrderQuotePartV1] ([SalesOrderQuoteId],[ItemMasterId],[ConditionId],[QtyRequested],[QtyQuoted],[CurrencyId],[FxRate],[PriorityId],[StatusId],[CustomerRequestDate],[PromisedDate],[EstimatedShipDate],[Notes],[MasterCompanyId],[CreatedBy],[CreatedDate],[UpdatedBy],[UpdatedDate],[IsActive],[IsDeleted],[IsLotAssigned],[LotId],UnitSalesPrice)
-				SELECT SalesOrderQuoteId, ItemMasterId, ConditionId, QtyRequested, QtyQuoted, CurrencyId, FxRate, PriorityId, @SOQPartStatus, CustomerRequestDate, PromisedDate, EstimatedShipDate, Notes, MasterCompanyId, CreatedBy, GETUTCDATE(), CreatedBy, GETUTCDATE(), 1, 0,IsLotAssigned,LotId,UnitSalesPrice
+				INSERT INTO [dbo].[SalesOrderQuotePartV1] ([SalesOrderQuoteId],[ItemMasterId],[ConditionId],[QtyRequested],[QtyQuoted],[CurrencyId],[FxRate],[PriorityId],[StatusId],[CustomerRequestDate],[PromisedDate],[EstimatedShipDate],[Notes],[MasterCompanyId],[CreatedBy],[CreatedDate],[UpdatedBy],[UpdatedDate],[IsActive],[IsDeleted],[IsLotAssigned],[LotId],UnitSalesPrice,SequenceNumber)
+				SELECT SalesOrderQuoteId, ItemMasterId, ConditionId, QtyRequested, QtyQuoted, CurrencyId, FxRate, PriorityId, @SOQPartStatus, CustomerRequestDate, PromisedDate, EstimatedShipDate, Notes, MasterCompanyId, CreatedBy, GETUTCDATE(), CreatedBy, GETUTCDATE(), 1, 0,IsLotAssigned,LotId,UnitSalesPrice,SequenceNumber
 				FROM #SOQPartDetails WHERE ID = @MinsoqId;
 
 				SET @SalesOrderQuotePartId = SCOPE_IDENTITY();
@@ -184,7 +187,7 @@ BEGIN
 			END
 			ELSE
 			BEGIN
-				SELECT @SalesOrderQuotePartId = SalesOrderQuotePartId FROM [dbo].[SalesOrderQuotePartV1] WITH (NOLOCK) WHERE ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId AND SalesOrderQuoteId = @SalesOrderQuoteId;
+				SELECT @SalesOrderQuotePartId = SalesOrderQuotePartId FROM [dbo].[SalesOrderQuotePartV1] WITH (NOLOCK) WHERE ItemMasterId = @ItemMasterId AND ConditionId = @ConditionId AND SalesOrderQuoteId = @SalesOrderQuoteId AND ISNULL(SequenceNumber,0) = ISNULL(@SequenceNumber,0);
 			END
 
 			IF (@StockLineId IS NOT NULL AND @StockLineId > 0) -- Added at Stockline Level
@@ -247,7 +250,8 @@ BEGIN
 			IsNoQuote = @IsNoQuote,
 			QtyRequested = @QtyRequested,
 			QtyQuoted = @QtyQuoted,
-			UnitSalesPrice = (CASE WHEN @StocklineCount > 0 THEN UnitSalesPrice ELSE @UnitSalesPrice END)
+			UnitSalesPrice = (CASE WHEN @StocklineCount > 0 THEN UnitSalesPrice ELSE @UnitSalesPrice END),
+			SequenceNumber = @SequenceNumber
 			WHERE SalesOrderQuotePartId = @SalesOrderQuotePartId
 
 			-- Update Part Details

--- a/PAS_DB/dbo/Stored Procedures/Procs2/USP_GetSOQAnalysisData.sql
+++ b/PAS_DB/dbo/Stored Procedures/Procs2/USP_GetSOQAnalysisData.sql
@@ -23,6 +23,7 @@
 	5    01/July/2026			 RAJESH GAMI						[PN-17008] - Merge Non Stock Inventory to ItemMaster : Get only Stock Inventory Data Where IsNonStock = 0
 	6    09/July/2026			 RAJESH GAMI						[PN-17009] - Merge Non-Stock Inventory to Stockline : Get only Stock Inventory Data Where IsNonStock = 0
 	7    22/July/2026			 RAJESH GAMI						[PN-17350] - Removed IsNonStock=0 exclusions from the StockLine (qs) and ItemMaster joins; Non-Stock parts were showing blank PN/description/qty/PO-RO details in the SOQ Analysis view.
+	8	 11/Aug/2026			 Kishor Makwana						[PN-17439]  - Concate Sequence Number in  ItemNo
 EXEC [dbo].[USP_GetSOQAnalysisData] 1300
 **************************************************************/
 CREATE   PROCEDURE [dbo].[USP_GetSOQAnalysisData] 
@@ -60,7 +61,7 @@ BEGIN
 				part.CreatedDate createdDate,
 				part.UpdatedBy updatedBy,
 				part.UpdatedDate updatedDate,
-				itemMaster.PartNumber partNumber,
+				CAST(part.SequenceNumber As VARCHAR(10) )+' - '+itemMaster.PartNumber AS partNumber,
 				itemMaster.PartDescription partDescription,
 				itemMaster.IsOEM isOEM,
 				itemMaster.IsPma AS isPMA,

--- a/PAS_DB/dbo/Tables/Tables4/SalesOrderPartV1.sql
+++ b/PAS_DB/dbo/Tables/Tables4/SalesOrderPartV1.sql
@@ -42,10 +42,13 @@
     [SizeHeight]            DECIMAL (10, 2) NULL,
     [AltOrEqType]           VARCHAR (50)    NULL,
     [UnitSalesPrice]        DECIMAL (18, 2) NULL,
+    [SequenceNumber]        BIGINT          DEFAULT (NULL) NULL,
     CONSTRAINT [PK_SalesOrderPartV1] PRIMARY KEY CLUSTERED ([SalesOrderPartId] ASC),
     CONSTRAINT [FK_SalesOrderPartV1_MasterCompany] FOREIGN KEY ([MasterCompanyId]) REFERENCES [dbo].[MasterCompany] ([MasterCompanyId]),
     CONSTRAINT [FK_SalesOrderPartV1_Priority] FOREIGN KEY ([PriorityId]) REFERENCES [dbo].[Priority] ([PriorityId])
 );
+
+
 
 
 

--- a/PAS_DB/dbo/Tables/Tables4/SalesOrderPartV1Audit.sql
+++ b/PAS_DB/dbo/Tables/Tables4/SalesOrderPartV1Audit.sql
@@ -43,6 +43,7 @@
     [SizeHeight]            DECIMAL (10, 2) NULL,
     [AltOrEqType]           VARCHAR (50)    NULL,
     [UnitSalesPrice]        DECIMAL (18, 2) NULL,
+    [SequenceNumber]        BIGINT          DEFAULT (NULL) NULL,
     CONSTRAINT [PK_SalesOrderPartV1Audit] PRIMARY KEY CLUSTERED ([AuditSalesOrderPartId] ASC)
 );
 

--- a/PAS_DB/dbo/Tables/Tables4/SalesOrderQuotePartV1.sql
+++ b/PAS_DB/dbo/Tables/Tables4/SalesOrderQuotePartV1.sql
@@ -33,10 +33,13 @@
     [StatusName]               VARCHAR (100)   NULL,
     [OldSalesOrderQuotePartId] BIGINT          NULL,
     [UnitSalesPrice]           DECIMAL (18, 2) NULL,
+    [SequenceNumber]           BIGINT          NULL,
     CONSTRAINT [PK_SalesOrderQuotePartV1] PRIMARY KEY CLUSTERED ([SalesOrderQuotePartId] ASC),
     CONSTRAINT [FK_SalesOrderQuotePartV1_MasterCompany] FOREIGN KEY ([MasterCompanyId]) REFERENCES [dbo].[MasterCompany] ([MasterCompanyId]),
     CONSTRAINT [FK_SalesOrderQuotePartV1_Priority] FOREIGN KEY ([PriorityId]) REFERENCES [dbo].[Priority] ([PriorityId])
 );
+
+
 
 
 

--- a/PAS_DB/dbo/Tables/Tables4/SalesOrderQuotePartV1Audit.sql
+++ b/PAS_DB/dbo/Tables/Tables4/SalesOrderQuotePartV1Audit.sql
@@ -34,6 +34,7 @@
     [StatusName]                 VARCHAR (100)   NULL,
     [OldSalesOrderQuotePartId]   BIGINT          NULL,
     [UnitSalesPrice]             DECIMAL (18, 2) NULL,
+    [SequenceNumber]             BIGINT          NULL,
     CONSTRAINT [PK_SalesOrderQuotePartV1Audit] PRIMARY KEY CLUSTERED ([AuditSalesOrderQuotePartId] ASC)
 );
 

--- a/PAS_DB/dbo/User Defined Types/SOPartListType.sql
+++ b/PAS_DB/dbo/User Defined Types/SOPartListType.sql
@@ -40,5 +40,6 @@
     [Weight]                DECIMAL (18, 4) NULL,
     [SizeLength]            DECIMAL (18, 4) NULL,
     [SizeWidth]             DECIMAL (18, 4) NULL,
-    [SizeHeight]            DECIMAL (18, 4) NULL);
+    [SizeHeight]            DECIMAL (18, 4) NULL,
+    [SequenceNumber]        BIGINT          NULL);
 

--- a/PAS_DB/dbo/User Defined Types/SOQPartListType.sql
+++ b/PAS_DB/dbo/User Defined Types/SOQPartListType.sql
@@ -38,5 +38,6 @@
     [CreatedBy]                  VARCHAR (100)   NULL,
     [IsNoQuote]                  BIT             NULL,
     [IsLotAssigned]              BIT             NULL,
-    [LotId]                      BIGINT          NULL);
+    [LotId]                      BIGINT          NULL,
+    [SequenceNumber]             INT             NULL);
 


### PR DESCRIPTION
The same PN + Condition can be added as multiple distinct line items in the SO Parts grid.
The same PN + Condition can be added as multiple distinct line items in the SOQ Parts grid.
Uniqueness is enforced on PN + Condition + SalesOrderPartId (no accidental record merging/collisions).
A Seq Num is generated and stored in the database for each part line.
Seq Num is displayed in the Parts grid and used to distinguish duplicate PN + Condition rows.